### PR TITLE
user-defined exclusion list

### DIFF
--- a/Logpresso/log4j2-scan-Linux-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Linux-run.bes.mustache
@@ -3,8 +3,23 @@
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 		<Title>Run: {{DisplayName}} v{{version}} - Linux{{#64BitOnly}} (x64){{/64BitOnly}}</Title>
 		<Description><![CDATA[
-This task will run {{DisplayName}} v{{version}} scanner.
-		]]></Description>
+This task will run {{DisplayName}} v{{version}} scanner.<br>
+<TABLE>
+<TBODY>
+<TR>
+<TD><LABEL for=exclusionlist>List additional directories to be excluded from the scan, one per line:</LABEL> </TD>
+<TD><TEXTAREA id=exclusionlist rows=10 cols=40 name=exclusionlist></TEXTAREA></TD></TR>
+</TBODY>
+</TABLE>
+<script>
+document.body.ontakeaction = function() {
+  TakeFixletAction( 
+	    Relevance('id of current fixlet'), Relevance('id of current bes site'), "Action1", {"exclusionlist": document.getElementById( "exclusionlist" ).value }, {} 
+		);
+  return false;
+}
+</script>
+		]]>		</Description>
 		<Relevance>unix of operating system</Relevance>
 		{{#64BitOnly}}
 		<Relevance><![CDATA["x86_64" = architecture of operating system]]></Relevance>
@@ -34,6 +49,8 @@ This task will run {{DisplayName}} v{{version}} scanner.
 				<PostLink> to run {{DisplayName}} v{{version}}.</PostLink>
 			</Description>
 			<ActionScript MIMEType="application/x-Fixlet-Windows-Shell"><![CDATA[
+//parameter "exclusionlist" is provided in the Description tab
+
 // Download {{DisplayName}}:
 {{{prefetch}}}
 
@@ -53,17 +70,31 @@ if {not exists folder (parameter "BPSFolder")}
 endif
 
 parameter "ListFile"="{parameter "BPSFolder"}results-{{DisplayName}}.txt"
+parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
 
 // Housekeeping, clear any previous scan output
 delete __createfile
+delete __appendfile
 delete "{parameter "ListFile"}"
+delete "{parameter "ExclusionFile"}"
+
+// default exclusions list
+appendfile {concatenation "%0a" of unique values whose(it does not contain " ") of (it;"/mnt";"/dev";"/cdrom") of items 0 of (mount points of it, filesystem types of it, types of it) whose(item 2 of it != "DRIVE_FIXED" OR item 1 of it is contained by set of ("cgroup";"cifs";"nfs";"cgroup2";"sysfs";"proc";"cpuset")) of filesystems}
+
+// user-provided custom exclusions list
+if {parameter "exclusionlist" as trimmed string != ""}
+	appendfile {parameter "exclusionlist"}
+endif
+
+move __appendfile "{parameter "ExclusionFile"}"
+
 
 // Run:
 // WARNING: this may scan network drives unintentionally!!!
-run sh -c 'cd /tmp && ./log4j2-scan {("--exclude " & it) of concatenations " --exclude " of unique values whose(it does not contain " ") of (it;"/mnt";"/dev";"/cdrom") of items 0 of (mount points of it, filesystem types of it, types of it) whose(item 2 of it != "DRIVE_FIXED" OR item 1 of it is contained by set of ("cgroup";"cifs";"nfs";"cgroup2";"sysfs";"proc";"cpuset")) of filesystems} / > "{parameter "ListFile"}"'
 
+run /bin/sh -c "cd /tmp && ./log4j2-scan --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}'"
 // End]]></ActionScript>
-      		<SuccessCriteria Option="OriginalRelevance"></SuccessCriteria>
+			<SuccessCriteria Option="OriginalRelevance"></SuccessCriteria>
 		</DefaultAction>
 	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 </BES>


### PR DESCRIPTION
Update the mustache template to provide a textarea in the Description tab for operator to add custom paths to exclude from scanning.
Update ActionScript to use an external file for path exclusions, and build that file on-the-fly with Relevance + the user-provided parameter.