### PR TITLE
Log4j-universal-scan-with-jre-download

### DIFF
--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -103,7 +103,7 @@ elseif {name of operating system as lowercase starts with "linux"}
   //endif
 
   // extract tar file to JRE folder
-  wait {parameter "tar"} -xzvf "__Download/jre.tar" -C "{parameter "JREFolder"}"
+  wait {parameter "tar"} -xzvf "__Download/jre.tar.gz" -C "{parameter "JREFolder"}"
 
 // - Handle extracting JRE for other operating systems here
 
@@ -146,7 +146,7 @@ parameter "shell_bin" = "{  tuple string items 0 of concatenations ", " of ( pat
 
 // Run log4j2-scan:
 // WARNING: this attempts to exclude network shares, but might not be perfect.
-run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' && '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}' && rm -rf '{parameter "JREFolder"}'"
+run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
 endif
 
 // Give 30 seconds for startup before checking

--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -6,7 +6,7 @@
 		<P><H3>NOTE:</H3> This version of the scan fixlet downloads the JAR version of {{DisplayName}} as well as a temporary Java Runtime from Adoptium/AdoptOpenJDK to execute the scanner.</P>
 		]]>		</Description>
 		<Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
-		<Relevance>windows of operating system or name of operating system as lowercase starts with "linux"</Relevance>
+		<Relevance>windows of operating system or name of operating system as lowercase starts with "linux" or (if exists property "mac" of type "operating system" then mac of operating system else name of operating system as lowercase as lowercase starts with "mac")</Relevance>
 		<Category></Category>
 		<DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
 		<Source>{{DisplayName}}</Source>
@@ -49,17 +49,22 @@ begin prefetch block
 	  add prefetch item name=jre.zip sha1=bf419f8c9231c34f0ffb9564b5f7f6690f596fd9 size=37494360 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x86-32_windows_hotspot_8u312b07.zip sha256=789cfa21858156084020ee885ade643556dc57ddec2b44745b5489edb7945b64
 	  add prefetch item name=unzip.exe sha1=84debf12767785cd9b43811022407de7413beb6f size=204800 url=http://software.bigfix.com/download/redist/unzip-6.0.exe sha256=2122557d350fd1c59fb0ef32125330bde673e9331eb9371b454c2ad2d82091ac
 	endif
-	// -- handle JRE downloads for other operating systems here
+	
+	if {if name of operating system as lowercase starts with "linux" then architecture of operating system = "x86_64" else false}
+        add prefetch item name=jre.tar.gz sha1=8b835bfff7f67d2a097344e95b7221d2d3c048ef size=41286015 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_linux_hotspot_8u312b07.tar.gz sha256=18fd13e77621f712326bfcf79c3e3cc08c880e3e4b8f63a1e5da619f3054b063
+	endif
+
+	if {if exists property "mac" of type "operating system" then mac of operating system else name of operating system as lowercase as lowercase starts with "mac"}
+		add prefetch item name=jre.tar.gz sha1=85bcaf8ab11b50e8ef2adda7d67751d504a46e70 size=45027148 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_mac_hotspot_8u312b07.tar.gz sha256=c8cf94118bd073c3caf0cde2389993ef7f482b46daa7b6f6d680f90d6de1dd3d
+	endif
+
+	// -- TODO: handle JRE downloads for other operating systems here
 		// add prefetch item name=OpenJDK8U-jre_aarch64_linux_hotspot_8u312b07.tar.gz sha1=daedd7d5c60df6a6035d28ec94d2a293d195c516 size=40312760 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_aarch64_linux_hotspot_8u312b07.tar.gz sha256=961df2d520987c2252496fbee024f84c8c8c4d0be80e9fe043d221191666899e
 		// add prefetch item name=OpenJDK8U-jre_arm_linux_hotspot_8u312b07.tar.gz sha1=fb502032c1c6d29da361a6032469a787aae59d58 size=38706993 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_arm_linux_hotspot_8u312b07.tar.gz sha256=5f37cbf311a5c2928aff8e83a82aebcf37b5911b193b5ab8538108381dcd6276
 		// add prefetch item name=OpenJDK8U-jre_ppc64_aix_hotspot_8u312b07.tar.gz sha1=e42ea144018ce547a13e85e4a2692b2fc0f45eeb size=42806130 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_ppc64_aix_hotspot_8u312b07.tar.gz sha256=735c2afd5fc4573a2cd3f1629f1fbc6607849f95230a494560037fa40bdc9e03
 		// add prefetch item name=OpenJDK8U-jre_sparcv9_solaris_hotspot_8u312b07.tar.gz sha1=513d89893df13f14e9b5e76a2f3134dd895fd1ef size=53232710 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_sparcv9_solaris_hotspot_8u312b07.tar.gz sha256=62db15678d4212307c3ccb6743cf44636d81cf08cbf150517a86f65f17f8900d
-		// add prefetch item name=OpenJDK8U-jre_x64_mac_hotspot_8u312b07.tar.gz sha1=85bcaf8ab11b50e8ef2adda7d67751d504a46e70 size=45027148 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_mac_hotspot_8u312b07.tar.gz sha256=c8cf94118bd073c3caf0cde2389993ef7f482b46daa7b6f6d680f90d6de1dd3d
 		// add prefetch item name=OpenJDK8U-jre_x64_solaris_hotspot_8u312b07.tar.gz sha1=8ab58046126953bb9acf3aa6b4d18d978e13e6d6 size=50196314 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_solaris_hotspot_8u312b07.tar.gz sha256=b4a3b701bfe0f529743d4260f1c776cc2bc95b80456bee539e0bc1931cba6117
 
-	if {if name of operating system as lowercase starts with "linux" then architecture of operating system = "x86_64" else false}
-        add prefetch item name=jre.tar.gz sha1=8b835bfff7f67d2a097344e95b7221d2d3c048ef size=41286015 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_linux_hotspot_8u312b07.tar.gz sha256=18fd13e77621f712326bfcf79c3e3cc08c880e3e4b8f63a1e5da619f3054b063
-	endif
 
 	collect prefetch items
 end prefetch block
@@ -84,29 +89,20 @@ parameter "JREFolder"="{pathname of parent folder of parent folder of client fol
 if {windows of operating system}
   waithidden __Download/unzip.exe "__Download/jre.zip" -d "{parameter "JREFolder"}"
 
-elseif {name of operating system as lowercase starts with "linux"}
-  //parameter "gunzip"="{tuple string items 0 of concatenation ", " of pathnames of files "gunzip" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
-  //parameter "gzip"="{tuple string items 0 of concatenation ", " of pathnames of files "gzip" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
-  parameter "tar"="{tuple string items 0 of concatenation ", " of pathnames of files "tar" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
+// TODO - verify mac works here
+elseif {(name of operating system as lowercase starts with "linux") or (if exists property "mac" of type "operating system" then mac of operating system else name of operating system as lowercase as lowercase starts with "mac")}
 
-  //If action stops here, gunzip or gzip may not be available
-  //continue if {parameter "gunzip" as trimmed string != "" or parameter "gzip" as trimmed string != ""}
+  parameter "tar"="{tuple string items 0 of concatenation ", " of pathnames of files "tar" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
 
   //If action stops here, tar may not be available
   continue if {parameter "tar" as trimmed string != ""}
-  
-  // decompress gz file
-  //if {parameter "gunzip" as trimmed string != ""}
-  //  wait {parameter "gunzip"} "__Download/jre.tar.gz"
-  //elseif {parameter "gzip" as trimmed string != ""}
-  //  wait {parameter "gzip"} -d "__Download/jre.tar.gz"
-  //endif
 
-  // extract tar file to JRE folder
+  // extract temporary JRE
   wait {parameter "tar"} -xzvf "__Download/jre.tar.gz" -C "{parameter "JREFolder"}"
-
-// - Handle extracting JRE for other operating systems here
-
+  
+else
+  // Operating system was not recognized.
+  continue if {false}
 endif
 
 
@@ -114,6 +110,9 @@ endif
 
 //locate Java binary
 parameter "Java_bin"="{tuple string item 0 of (concatenation ", " of pathnames of files ("java";"java.exe") of folders "bin" of folders of folders (parameter "JREFolder"))}"
+
+// If script fails here, the JRE extraction may have failed.
+continue if {exists file (parameter "Java_bin")}
 
 // Setup logpresso-log4j2-scan.jar
 delete "{pathname of file "logpresso-log4j2-scan.jar" of folder (parameter "BPSFolder")}"
@@ -128,25 +127,30 @@ delete "{parameter "ExclusionFile"}"
 
 if {windows of operating system}
 
-// Create Exclusions list file:
-appendfile {concatenation "%0d%0a" of unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | "")}
-copy __appendfile "{parameter "ExclusionFile"}"
+  // Create Exclusions list file:
+  appendfile {concatenation "%0d%0a" of unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | "")}
+  copy __appendfile "{parameter "ExclusionFile"}"
+  
+  // Execute scan
+  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config "{parameter "ExclusionFile"}"> "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
 
-runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config "{parameter "ExclusionFile"}"> "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
+elseif {(name of operating system as lowercase starts with "linux") or (if exists property "mac" of type "operating system" then mac of operating system else name of operating system as lowercase as lowercase starts with "mac")}
 
-else // non-Windows operating system:
+  // Create Exclusions list file:
+  appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of unique values whose(it does not contain " ") of (it;"/mnt";"/dev";"/cdrom"; (unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | "")) ) of items 0 of (mount points of it, filesystem types of it, types of it) whose(item 2 of it != "DRIVE_FIXED" OR item 1 of it is contained by set of ("cgroup";"cifs";"nfs";"nfs3";"nfs4";"cgroup2";"sysfs";"proc";"cpuset")) of filesystems}
+  
+  copy __appendfile "{parameter "ExclusionFile"}"
+  
+  // Get shell binary, should return /bin/sh in most cases:
+  parameter "shell_bin" = "{  tuple string items 0 of concatenations ", " of ( pathnames of files "/bin/sh"; pathnames of files whose(name of it as lowercase = "sh" OR name of it as lowercase = "sh.exe") of (folders it) of unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments) }"
+  
+  // Run log4j2-scan:
+  // WARNING: this attempts to exclude network shares, but might not be perfect.
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
 
-// Create Exclusions list file:
-appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of unique values whose(it does not contain " ") of (it;"/mnt";"/dev";"/cdrom"; (unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | "")) ) of items 0 of (mount points of it, filesystem types of it, types of it) whose(item 2 of it != "DRIVE_FIXED" OR item 1 of it is contained by set of ("cgroup";"cifs";"nfs";"nfs3";"nfs4";"cgroup2";"sysfs";"proc";"cpuset")) of filesystems}
-
-copy __appendfile "{parameter "ExclusionFile"}"
-
-// Get shell binary, should return /bin/sh in most cases:
-parameter "shell_bin" = "{  tuple string items 0 of concatenations ", " of ( pathnames of files "/bin/sh"; pathnames of files whose(name of it as lowercase = "sh" OR name of it as lowercase = "sh.exe") of (folders it) of unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments) }"
-
-// Run log4j2-scan:
-// WARNING: this attempts to exclude network shares, but might not be perfect.
-run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
+else 
+  // Did not recognize the OS.  Adding more is on the roadmap.
+  continue if {false}
 endif
 
 // Give 30 seconds for startup before checking

--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
+	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
+		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - Download JRE</Title>
+		<Description><![CDATA[{{>Log4J2Scan-Description}}
+		<P><H3>NOTE:</H3> This version of the scan fixlet downloads the JAR version of {{DisplayName}} as well as a temporary Java Runtime from Adoptium/AdoptOpenJDK to execute the scanner.</P>
+		]]>		</Description>
+		<Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
+		<Relevance>windows of operating system or name of operating system as lowercase starts with "linux"</Relevance>
+		<Category></Category>
+		<DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
+		<Source>{{DisplayName}}</Source>
+		<SourceID></SourceID>
+		<SourceReleaseDate>{{SourceReleaseDate}}</SourceReleaseDate>
+		<SourceSeverity></SourceSeverity>
+		<CVENames></CVENames>
+		<SANSID></SANSID>
+		<MIMEField>
+			<Name>action-ui-metadata</Name>
+			<Value>{ {{#version}}"version":"{{version}}",{{/version}}"size":{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}{{^patch}}{{#icon_base64}},"icon":"data:{{icon_type}}{{^icon_type}}image/png{{/icon_type}};base64,{{icon_base64}}"{{/icon_base64}}{{/patch}} }</Value>
+		</MIMEField>
+		<MIMEField>
+			<Name>x-fixlet-modification-time</Name>
+			<Value>{{x-fixlet-modification-time}}</Value>
+		</MIMEField>
+		<MIMEField>
+			<Name>x-relevance-evaluation-period</Name>
+			<Value>01:00:00</Value>
+		</MIMEField>
+		<Domain>BESC</Domain>
+		<DefaultAction ID="Action1">
+			<Description>
+				<PreLink>Click </PreLink>
+				<Link>here</Link>
+				<PostLink> to run {{DisplayName}} v{{version}}.</PostLink>
+			</Description>
+			<ActionScript MIMEType="application/x-Fixlet-Windows-Shell"><![CDATA[
+//parameter "exclusionlist" is provided in the Description tab
+begin prefetch block
+	// Download {{DisplayName}}:
+	{{{prefetch}}}
+	
+	// trap for 'x64 of operating system' property existing only on Windows
+	if {if windows of operating system then x64 of operating system else false}
+ 	  add prefetch item name=jre.zip sha1=359ef250b3e78716cee4669b0182f0c1c28261c3 size=39046089 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_windows_hotspot_8u312b07.zip sha256=a4623365d70e7bc969e84b7f29b6b2eecb6c0686863ed67651506e2b5adf43b0
+ 	  add prefetch item name=unzip.exe sha1=84debf12767785cd9b43811022407de7413beb6f size=204800 url=http://software.bigfix.com/download/redist/unzip-6.0.exe sha256=2122557d350fd1c59fb0ef32125330bde673e9331eb9371b454c2ad2d82091ac
+	endif
+	if {if windows of operating system then not x64 of operating system else false}
+	  add prefetch item name=jre.zip sha1=bf419f8c9231c34f0ffb9564b5f7f6690f596fd9 size=37494360 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x86-32_windows_hotspot_8u312b07.zip sha256=789cfa21858156084020ee885ade643556dc57ddec2b44745b5489edb7945b64
+	  add prefetch item name=unzip.exe sha1=84debf12767785cd9b43811022407de7413beb6f size=204800 url=http://software.bigfix.com/download/redist/unzip-6.0.exe sha256=2122557d350fd1c59fb0ef32125330bde673e9331eb9371b454c2ad2d82091ac
+	endif
+	// -- handle JRE downloads for other operating systems here
+		// add prefetch item name=OpenJDK8U-jre_aarch64_linux_hotspot_8u312b07.tar.gz sha1=daedd7d5c60df6a6035d28ec94d2a293d195c516 size=40312760 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_aarch64_linux_hotspot_8u312b07.tar.gz sha256=961df2d520987c2252496fbee024f84c8c8c4d0be80e9fe043d221191666899e
+		// add prefetch item name=OpenJDK8U-jre_arm_linux_hotspot_8u312b07.tar.gz sha1=fb502032c1c6d29da361a6032469a787aae59d58 size=38706993 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_arm_linux_hotspot_8u312b07.tar.gz sha256=5f37cbf311a5c2928aff8e83a82aebcf37b5911b193b5ab8538108381dcd6276
+		// add prefetch item name=OpenJDK8U-jre_ppc64_aix_hotspot_8u312b07.tar.gz sha1=e42ea144018ce547a13e85e4a2692b2fc0f45eeb size=42806130 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_ppc64_aix_hotspot_8u312b07.tar.gz sha256=735c2afd5fc4573a2cd3f1629f1fbc6607849f95230a494560037fa40bdc9e03
+		// add prefetch item name=OpenJDK8U-jre_sparcv9_solaris_hotspot_8u312b07.tar.gz sha1=513d89893df13f14e9b5e76a2f3134dd895fd1ef size=53232710 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_sparcv9_solaris_hotspot_8u312b07.tar.gz sha256=62db15678d4212307c3ccb6743cf44636d81cf08cbf150517a86f65f17f8900d
+		// add prefetch item name=OpenJDK8U-jre_x64_mac_hotspot_8u312b07.tar.gz sha1=85bcaf8ab11b50e8ef2adda7d67751d504a46e70 size=45027148 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_mac_hotspot_8u312b07.tar.gz sha256=c8cf94118bd073c3caf0cde2389993ef7f482b46daa7b6f6d680f90d6de1dd3d
+		// add prefetch item name=OpenJDK8U-jre_x64_solaris_hotspot_8u312b07.tar.gz sha1=8ab58046126953bb9acf3aa6b4d18d978e13e6d6 size=50196314 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_solaris_hotspot_8u312b07.tar.gz sha256=b4a3b701bfe0f529743d4260f1c776cc2bc95b80456bee539e0bc1931cba6117
+
+	if {if name of operating system as lowercase starts with "linux" then architecture of operating system = "x86_64" else false}
+        add prefetch item name=jre.tar.gz sha1=8b835bfff7f67d2a097344e95b7221d2d3c048ef size=41286015 url=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_linux_hotspot_8u312b07.tar.gz sha256=18fd13e77621f712326bfcf79c3e3cc08c880e3e4b8f63a1e5da619f3054b063
+	endif
+
+	collect prefetch items
+end prefetch block
+
+utility __Download/logpresso-log4j2-scan.jar
+if {exists file "__Download\unzip.exe"}
+  utility __Download/unzip.exe
+endif
+if {exists file "__Download\jre.zip"}
+  utility __Download/jre.zip
+endif
+
+folder create "{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans"
+folder create "{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans/jre"
+
+parameter "BPSFolder"="{pathname of folder "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"}{if windows of operating system then "\" else "/"}"
+parameter "ListFile"="{parameter "BPSFolder"}results-log4j2-scan.txt"
+parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
+parameter "JREFolder"="{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans/jre"
+
+// --- Begin JRE extraction
+if {windows of operating system}
+  waithidden __Download/unzip.exe "__Download/jre.zip" -d "{parameter "JREFolder"}"
+
+elseif {name of operating system as lowercase starts with "linux"}
+  //parameter "gunzip"="{tuple string items 0 of concatenation ", " of pathnames of files "gunzip" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
+  //parameter "gzip"="{tuple string items 0 of concatenation ", " of pathnames of files "gzip" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
+  parameter "tar"="{tuple string items 0 of concatenation ", " of pathnames of files "tar" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
+
+  //If action stops here, gunzip or gzip may not be available
+  //continue if {parameter "gunzip" as trimmed string != "" or parameter "gzip" as trimmed string != ""}
+
+  //If action stops here, tar may not be available
+  continue if {parameter "tar" as trimmed string != ""}
+  
+  // decompress gz file
+  //if {parameter "gunzip" as trimmed string != ""}
+  //  wait {parameter "gunzip"} "__Download/jre.tar.gz"
+  //elseif {parameter "gzip" as trimmed string != ""}
+  //  wait {parameter "gzip"} -d "__Download/jre.tar.gz"
+  //endif
+
+  // extract tar file to JRE folder
+  wait {parameter "tar"} -xzvf "__Download/jre.tar" -C "{parameter "JREFolder"}"
+
+// - Handle extracting JRE for other operating systems here
+
+endif
+
+
+// --- End JRE extraction
+
+//locate Java binary
+parameter "Java_bin"="{tuple string item 0 of (concatenation ", " of pathnames of files ("java";"java.exe") of folders "bin" of folders of folders (parameter "JREFolder"))}"
+
+// Setup logpresso-log4j2-scan.jar
+delete "{pathname of file "logpresso-log4j2-scan.jar" of folder (parameter "BPSFolder")}"
+
+// Copy the scanner JAR file to client folder
+copy __Download/logpresso-log4j2-scan.jar "{parameter "BPSFolder"}/logpresso-log4j2-scan.jar"
+
+// Delete previous items
+delete "{parameter "ListFile"}"
+delete __appendfile
+delete "{parameter "ExclusionFile"}"
+
+if {windows of operating system}
+
+// Create Exclusions list file:
+appendfile {concatenation "%0d%0a" of unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | "")}
+copy __appendfile "{parameter "ExclusionFile"}"
+
+runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config "{parameter "ExclusionFile"}"> "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
+
+else // non-Windows operating system:
+
+// Create Exclusions list file:
+appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of unique values whose(it does not contain " ") of (it;"/mnt";"/dev";"/cdrom"; (unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | "")) ) of items 0 of (mount points of it, filesystem types of it, types of it) whose(item 2 of it != "DRIVE_FIXED" OR item 1 of it is contained by set of ("cgroup";"cifs";"nfs";"nfs3";"nfs4";"cgroup2";"sysfs";"proc";"cpuset")) of filesystems}
+
+copy __appendfile "{parameter "ExclusionFile"}"
+
+// Get shell binary, should return /bin/sh in most cases:
+parameter "shell_bin" = "{  tuple string items 0 of concatenations ", " of ( pathnames of files "/bin/sh"; pathnames of files whose(name of it as lowercase = "sh" OR name of it as lowercase = "sh.exe") of (folders it) of unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments) }"
+
+// Run log4j2-scan:
+// WARNING: this attempts to exclude network shares, but might not be perfect.
+run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' && '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}' && rm -rf '{parameter "JREFolder"}'"
+endif
+
+// Give 30 seconds for startup before checking
+parameter "StartTime"="{now}"
+pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
+// Check that an output log file has been created as an indicator that the scan has launched successfully
+continue if {exists file (parameter "ListFile") whose (modification time of it >= active start time of action)}
+
+// End]]></ActionScript>
+		</DefaultAction>
+	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
+</BES>

--- a/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
@@ -1,0 +1,36 @@
+---
+Description: Generates a BigFix Task for running the latest log4j2-scan
+Identifier: com.github.jgstew.bigfix.log4j2-scan-Universal-JRE
+Input:
+  # Name: Short Name of the Software, No spaces, Example: "DBBrowserforSQLite"
+  NAME: log4j2-scan
+  DisplayName: log4j2-scan
+# MinimumVersion of AutoPkg - Should always be 2.3 (or higher once a new version is released)
+MinimumVersion: "2.3"
+ParentRecipe: com.github.jgstew.download.log4j2-scan-Universal-JRE
+Process:
+  # `SharedUtilityMethods` must come first
+  - Processor: com.github.jgstew.SharedProcessors/SharedUtilityMethods
+  # `BigFixPrefetchItem` takes the hashes from `URLDownloaderPython`
+  #   Then it assembles them into a BigFix Prefetch Statement or Block
+  - Processor: com.github.jgstew.SharedProcessors/BigFixPrefetchItem
+    Arguments:
+      prefetch_type: block
+
+  # `BigFixSetupTemplateDictionary` creates a dictionary to fill out a bigix content template
+  #   If `SourceReleaseDate` is not provided, it will be set to today
+  - Processor: com.github.jgstew.SharedProcessors/BigFixSetupTemplateDictionary
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppendInput
+
+  # `ContentFromTemplate` generates bigfix content from a mustache template file
+  #   The file is filled out with variables from the Template Dictionary
+  #   If variables are missing from the Template Dictionary, then that area will be blank
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      template_file_path: "./%VendorFolder%/%NAME%-Universal-JRE-run.bes.mustache"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/%NAME%.bes"
+
+  # `BESImport` imports the generated BES content into a BigFix Server
+  #   Which server and credentials are used is dictated by `~/.besapi.conf`
+  - Processor: com.github.jgstew.SharedProcessors/BESImport

--- a/Logpresso/log4j2-scan-Universal-JRE.download.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal-JRE.download.recipe.yaml
@@ -1,0 +1,12 @@
+---
+Description: Downloads the latest version of log4j2-scan
+Identifier: com.github.jgstew.download.log4j2-scan-Universal-JRE
+Input:
+  NAME: "log4j2-scan"
+  # TYPE must be `zip` or `7z` or `tar.gz`
+  TYPE: jar
+  OS: ""
+MinimumVersion: "2.3"
+ParentRecipe: com.github.jgstew.download.log4j2-scan-Win64
+Process:
+  - Processor: EndOfCheckPhase


### PR DESCRIPTION
Recipe for log4jscan using temporary JRE
Tested on Windows x64 and CentOS 7.9 x64
Untested for Windows x86 and Mac OS X but the code is there to test.
Other operating systems TODO