### PR TITLE
log4j-core-2.x.jar file replacement

### DIFF
--- a/.templates/.partials/ActionPrefetchBlockUnzipExe.mustache
+++ b/.templates/.partials/ActionPrefetchBlockUnzipExe.mustache
@@ -1,0 +1,2 @@
+// download Unzip
+add prefetch item name=unzip.exe sha1=84debf12767785cd9b43811022407de7413beb6f size=204800 url=http://software.bigfix.com/download/redist/unzip-6.0.exe sha256=2122557d350fd1c59fb0ef32125330bde673e9331eb9371b454c2ad2d82091ac

--- a/.templates/.partials/Description-CommunityTestStatement.mustache
+++ b/.templates/.partials/Description-CommunityTestStatement.mustache
@@ -1,0 +1,2 @@
+<P><H3>This is Community Content.  When you use these solutions, it is incumbent on your organization to test any solutions provided across the broadest available system base including various OS, storage solutions, and application inventory.</H3></P>
+<P>Please see the <A href="https://forum.bigfix.com/t/log4j-vulnerability-identification-and-3rd-party-remediation-solution-testing-statement/40273"> Community Solution Testing Statement</A></P>

--- a/.templates/.partials/Log4J2Scan-Description-Links.mustache
+++ b/.templates/.partials/Log4J2Scan-Description-Links.mustache
@@ -1,0 +1,19 @@
+<P>This content is part of a series of community-curated Fixlets, Tasks, and Analyses geared toward finding and remediating Log4j vulnerabilities, including the CVEs referenced at the following URLs:</P>
+<P>
+<A href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105</A><BR>
+<A href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046</A><BR>
+<A href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228</A><BR>
+<A href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4104">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4104</A></P>
+
+<P>This is part of a series of content currently published through a community GitHub site.&nbsp; Links to related content include</P>
+<P>Analysis:</P>
+<P><A href="https://github.com/jgstew/bigfix-content/blob/master/analyses/log4j2-scan%20results.bes">log4j2-scan results</A></P>
+<P>Scanning Tasks:<BR>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Universal.bes">Logpresso log4j2-scan - Universal.bes</A><BR>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20Log4j2-scan%20-%20Universal%20-%20JRE.bes">Logpresso Log4j2-scan - Universal - JRE.bes</A><BR>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Windows%20x64.bes">Logpresso log4j2-scan - Windows x64.bes</A><BR>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Linux%20x64.bes">Logpresso log4j2-scan - Linux x64.bes</A><BR>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20MacOS%20x64.bes">Logpresso log4j2-scan - MacOS x64.bes</A></P>
+<P><BR>&nbsp;(be sure to check for the latest version).</P>
+<P>For the latest details and discussion of this content, please see <A href="https://forum.bigfix.com/t/log4j-cve-2021-44228-cve-2021-45046-summary-page/40222">https://forum.bigfix.com/t/log4j-cve-2021-44228-cve-2021-45046-summary-page/40222</A></P>
+<P>&nbsp;</P>

--- a/.templates/.partials/Log4JScan-Description-Remediation.mustache
+++ b/.templates/.partials/Log4JScan-Description-Remediation.mustache
@@ -1,0 +1,1 @@
+<P><H3>This Action will attempt to remediate the vulnerability by using Log4j-Scan to modify the affected JAR files and remove the JndiLookup.class entry.</H3></P>

--- a/Apache/log4j2-replace-Win.bes.mustache
+++ b/Apache/log4j2-replace-Win.bes.mustache
@@ -1,12 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>CVE-2021-44228 Log4j - Replace log4j-core-2.x.jar with log4j-core-{{version}}.jar - Windows</Title>
+		<Title>CVE-2021-44228 Log4j - Replace log4j-core-2.x.jar with log4j-core-{{version}}.jar - Universal</Title>
 		<Description><![CDATA[
-This task will run replace log4j-core-2.x.jar with log4j-core-{{version}}.jar
-		]]></Description>
-		<Relevance>windows of operating system</Relevance>
-		<Relevance><![CDATA[exists files "BPS-Scans/CVE-2021-44228.txt" of parent folders of parent folders of client folders of sites "actionsite"]]></Relevance>
+This task will run replace log4j-core-2.x.jar with log4j-core-{{version}}.jar<p>
+<P>This Task requires a prior execution of one of the Log4jscan tasks, currently linked at <br>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Universal.bes">Logpresso log4j2-scan - Universal.bes</A><br>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20Log4j2-scan%20-%20Universal%20-%20JRE.bes">Logpresso Log4j2-scan - Universal - JRE.bes</A><br>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Windows%20x64.bes">Logpresso log4j2-scan - Windows x64.bes</A><br>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Linux%20x64.bes">Logpresso log4j2-scan - Linux x64.bes</A><br>
+<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20MacOS%20x64.bes">Logpresso log4j2-scan - MacOS x64.bes</A><br>
+&nbsp;(be sure to check for the latest version).</P>
+<P>Where the Scan Task found log4j-core.2.x.jar, this Task will rename that file to log4j-core-2.x.jar-disabled, and replace the original file with log4j-core-{{version}}.jar.</P>
+<P> Note that only files matching the log4j-core-2.x.jar format are replaced.  This task does not replace files that were renamed or log4j-1.x versions.</p>
+<P> Follow this task by re-executing one of the scans listed above to ensure the issues have been remediated</p>
+<P>The original filename will be retained for better compatibility with existing configuration files.</P>
+<P>This operation does carry risk, as it is difficult to predict how replacing the JAR file might affect the larger application.&nbsp; No warranty expressed, use at your own risk.</P>
+<P>&nbsp;</P>
+		]]>		</Description>
+		<Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
+		<Relevance>exists files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite"</Relevance>
 		<Category></Category>
 		<DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
 		<Source>{{DisplayName}}</Source>
@@ -31,46 +44,63 @@ This task will run replace log4j-core-2.x.jar with log4j-core-{{version}}.jar
 				<PostLink> to replace log4j-core-2.x.jar with log4j-core-{{version}}.jar</PostLink>
 			</Description>
 			<ActionScript MIMEType="application/x-Fixlet-Windows-Shell"><![CDATA[
+//log4j-core-{{version}}.jar properties:
+// sha1 {{log4j-core-sha1}}
+// size {{log4j-core-size}}
+// sha256 {{log4j-core-sha256}}
+
+begin prefetch block
 // Download:
-{{{prefetch}}}
-{{>ActionPrefetchUnzipExe}}
+if {exists files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
+  {{{prefetch}}}
+  if {windows of operating system}
+    {{>ActionPrefetchBlockUnzipExe}}
+  endif
+endif
 
-// BES Client Folder Determination
-if {name of operating system as lowercase starts with "win"}
-    parameter "BPSFolder" = "{pathname of parent folder of client}\BPS-Scans\"
+end prefetch block
+// Check that a scan result lists vulnerable files, the files match our pattern, and the file has not already been replaced before executing replacements
+
+if {not exists files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
+parameter "LogMessage"="No vulnerable fixable files found, skipping action"
 else
-    parameter "BPSFolder" = "{(if (version of client >= "9" as version) then (pathname of parent folder of data folder of client) else (pathname of parent folder of parent folder of client folder of site "actionsite"))}/BPS-Scans/"
+  if {windows of operating system}
+    utility __Download\unzip.exe
+    waithidden __Download\unzip.exe __Download\apache-log4j-{{version}}-bin.zip -d __Download
+    delete __appendfile
+    appendfile REM Preserve existing JAR files
+	appendfile REM COPY /N is used on the backup so the original JAR is backed up only once
+    appendfile {concatenation "%0d%0a" of ("COPY /N %22" & it & "%22 %22" & it & "-disabled%22") of pathnames of files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
+    appendfile REM Overwrite with log4j-core-{{version}}.jar
+    appendfile {concatenation "%0d%0a" of ("COPY /Y %22__Download\apache-log4j-{{version}}-bin\log4j-core-{{version}}.jar%22 %22" & it & "%22") of pathnames of files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
+    
+    delete replace_log4j.cmd
+    move __appendfile replace_log4j.cmd
+    action uses wow64 redirection {not x64 of operating system}
+    waithidden cmd.exe /c replace_log4j.cmd
+  else
+    parameter "shell_bin" = "{ tuple string items 0 of concatenations ", " of pathnames of files "sh" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
+    parameter "unzip"="{tuple string items 0 of concatenation ", " of pathnames of files "unzip" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
+    wait {parameter "unzip"} __Download/apache-log4j-{{version}}-bin.zip -d __Download
+    delete __appendfile
+    appendfile #!/bin/sh
+	appendfile # \cp is used to prevent the common 'cp -i' alias from being used
+	appendfile # -n is used to prevent clobbering destination.  We only want to backup the first, original version, of log4j-core
+    appendfile {concatenation "%0a" of ("\cp -n %22" & it & "%22 %22" & it & "-disabled%22") of pathnames of files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
+    appendfile {concatenation "%0a" of ("\cp %22__Download/apache-log4j-{{version}}-bin/log4j-core-{{version}}.jar%22 %22" & it & "%22") of pathnames of files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
+  
+    delete ./replace_log4j.sh
+    move __appendfile ./replace_log4j.sh
+    wait {parameter "shell_bin"} -c "chmod +x ./replace_log4j.sh"
+    wait {parameter "shell_bin"} -c "./replace_log4j.sh"
+  endif
+  
+  // Check success - no un-fixed log4j-core-2.x.jar files remain.  Their sha hashes should be updated to reflect the 2.16.0 version
+  continue if {not exists files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
+  action requires restart "log4j_file_replacement_{{version}}"
 endif
-
-//Check scan results to see whether any vulnerable log4j-core-2.x.jar files are found, before asking to download the new version
-if {exists files( lines of files "CVE-2021-44228.txt" of folders "BPS-Scans" of parent folder of client) whose (name of it as lowercase starts with "log4j-core-2." and name of it as lowercase does not end with "-javadoc.jar" and name of it as lowercase does not end with "-sources.jar" and name of it as lowercase does not end with "-tests.jar" and name of it as version < version "{{version}}" and size of it != {{DownloadSize}} and sha1 of it != "{{file_sha1}}") }
-
-waithidden __Download\unzip.exe -o __Download\{{file_name}} -d __Download
-
-delete __createfile
-createfile until EOF_EOF_EOF
-REM Preserve existing JAR files
-{concatenation "%0d%0a" of ("COPY /Y %22" & it & "%22 %22" & it & "-disabled%22") of (pathname of it) of files( lines of files "CVE-2021-44228.txt" of folders "BPS-Scans" of parent folder of client) whose (name of it as lowercase starts with "log4j-core-2." and name of it as lowercase does not end with "-javadoc.jar" and name of it as lowercase does not end with "-sources.jar" and name of it as lowercase does not end with "-tests.jar" and name of it as version < version "2.16.0" and size of it != 1789565 and sha1 of it != "539a445388aee52108700f26d9644989e7916e7c")}
-
-REM Overwrite with log4j-core-2.16.0.jar
-{concatenation "%0d%0a" of ("COPY /Y %22__Download\apache-log4j-2.16.0-bin\log4j-core-2.16.0.jar%22 %22" & it & "%22") of (pathname of it) of files( lines of files "CVE-2021-44228.txt" of folders "BPS-Scans" of parent folder of client) whose (name of it as lowercase starts with "log4j-core-2." and name of it as lowercase does not end with "-javadoc.jar" and name of it as lowercase does not end with "-sources.jar" and name of it as lowercase does not end with "-tests.jar" and name of it as version < version "2.16.0" and size of it != 1789565 and sha1 of it != "539a445388aee52108700f26d9644989e7916e7c")}
-
-EOF_EOF_EOF
-
-delete replace_log4j.cmd
-move __createfile replace_log4j.cmd
-
-action uses wow64 redirection {not x64 of operating system}
-waithidden cmd.exe /c replace_log4j.cmd
-
-// Check success - no un-fixed log4j-core-2.x.jar files remain.  Their sha hashes should be updated to reflect the 2.16.0 version
-continue if {exists lines of files "CVE-2021-44228.txt" of folders "BPS-Scans" of parent folder of client AND not exists files( lines of files "CVE-2021-44228.txt" of folders "BPS-Scans" of parent folder of client) whose (name of it as lowercase starts with "log4j-core-2." and name of it as lowercase does not end with "-javadoc.jar" and name of it as lowercase does not end with "-sources.jar" and name of it as lowercase does not end with "-tests.jar" and name of it as version < version "2.16.0" and size of it != 1789565 and sha1 of it != "539a445388aee52108700f26d9644989e7916e7c") }
-action requires restart "log4j_file_replacement"
-
-endif
-
 // End]]></ActionScript>
-      		<SuccessCriteria Option="OriginalRelevance"></SuccessCriteria>
+			<SuccessCriteria Option="OriginalRelevance"></SuccessCriteria>
 		</DefaultAction>
 	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 </BES>

--- a/Apache/log4j2-replace-Win.bes.mustache
+++ b/Apache/log4j2-replace-Win.bes.mustache
@@ -66,7 +66,7 @@ parameter "LogMessage"="No vulnerable fixable files found, skipping action"
 else
   if {windows of operating system}
     utility __Download\unzip.exe
-    waithidden __Download\unzip.exe __Download\apache-log4j-bin.zip -d __Download
+    waithidden __Download\unzip.exe __Download\{{file_name}} -d __Download
     delete __appendfile
     appendfile REM log4j-core-2.x.jar replacement script {now as string}
 	appendfile REM Preserve existing JAR files
@@ -83,7 +83,7 @@ else
   else
     parameter "shell_bin" = "{ tuple string items 0 of concatenations ", " of pathnames of files "sh" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
     parameter "unzip"="{tuple string items 0 of concatenation ", " of pathnames of files "unzip" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
-    wait {parameter "unzip"} __Download/apache-log4j-bin.zip -d __Download
+    wait {parameter "unzip"} __Download/{{file_name}} -d __Download
     delete __appendfile
     appendfile #!/bin/sh
 	appendfile # log4j-core-2.x.jar replacement script {now as string}

--- a/Apache/log4j2-replace-Win.bes.mustache
+++ b/Apache/log4j2-replace-Win.bes.mustache
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>CVE-2021-44228 Log4j - Replace log4j-core-2.x.jar with log4j-core-{{version}}.jar - Universal</Title>
+		<Title>Run: Log4j2 Remediation - Replace log4j-core-2.x.jar with log4j-core-{{version}}.jar - Universal</Title>
 		<Description><![CDATA[
-This task will run replace log4j-core-2.x.jar with log4j-core-{{version}}.jar<p>
-<P>This Task requires a prior execution of one of the Log4jscan tasks, currently linked at <br>
-<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Universal.bes">Logpresso log4j2-scan - Universal.bes</A><br>
-<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20Log4j2-scan%20-%20Universal%20-%20JRE.bes">Logpresso Log4j2-scan - Universal - JRE.bes</A><br>
-<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Windows%20x64.bes">Logpresso log4j2-scan - Windows x64.bes</A><br>
-<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20Linux%20x64.bes">Logpresso log4j2-scan - Linux x64.bes</A><br>
-<A href="https://github.com/jgstew/bigfix-content/blob/master/fixlet/Logpresso%20log4j2-scan%20-%20MacOS%20x64.bes">Logpresso log4j2-scan - MacOS x64.bes</A><br>
-&nbsp;(be sure to check for the latest version).</P>
+		
+{{>Description-CommunityTestStatement}}
+</P>
+{{>Log4J2Scan-Description-Links}}
+
+<P>This task will replace log4j-core-2.x.jar with log4j-core-{{version}}.jar</P>
+
 <P>Where the Scan Task found log4j-core.2.x.jar, this Task will rename that file to log4j-core-2.x.jar-disabled, and replace the original file with log4j-core-{{version}}.jar.</P>
 <P> Note that only files matching the log4j-core-2.x.jar format are replaced.  This task does not replace files that were renamed or log4j-1.x versions.</p>
 <P> Follow this task by re-executing one of the scans listed above to ensure the issues have been remediated</p>
 <P>The original filename will be retained for better compatibility with existing configuration files.</P>
+<P>The script to replace files, as well as the output of executing the script, are stored beneath the BES Client directory/BPS-Scans folder which may be useful in troubleshooting or rolling back changes.</P>
 <P>This operation does carry risk, as it is difficult to predict how replacing the JAR file might affect the larger application.&nbsp; No warranty expressed, use at your own risk.</P>
 <P>&nbsp;</P>
 		]]>		</Description>
@@ -66,9 +66,10 @@ parameter "LogMessage"="No vulnerable fixable files found, skipping action"
 else
   if {windows of operating system}
     utility __Download\unzip.exe
-    waithidden __Download\unzip.exe __Download\apache-log4j-{{version}}-bin.zip -d __Download
+    waithidden __Download\unzip.exe __Download\apache-log4j-bin.zip -d __Download
     delete __appendfile
-    appendfile REM Preserve existing JAR files
+    appendfile REM log4j-core-2.x.jar replacement script {now as string}
+	appendfile REM Preserve existing JAR files
 	appendfile REM COPY /N is used on the backup so the original JAR is backed up only once
     appendfile {concatenation "%0d%0a" of ("COPY /N %22" & it & "%22 %22" & it & "-disabled%22") of pathnames of files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
     appendfile REM Overwrite with log4j-core-{{version}}.jar
@@ -76,14 +77,16 @@ else
     
     delete replace_log4j.cmd
     move __appendfile replace_log4j.cmd
+	copy replace_log4j.cmd "{pathname of folder "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite"}/replace_log4j-{id of action as string}.txt"
     action uses wow64 redirection {not x64 of operating system}
-    waithidden cmd.exe /c replace_log4j.cmd
+    waithidden cmd.exe /c "replace_log4j.cmd > "{pathname of folder "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite"}\replace_log4j-{id of action as string}_output.txt" 2>&1"
   else
     parameter "shell_bin" = "{ tuple string items 0 of concatenations ", " of pathnames of files "sh" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
     parameter "unzip"="{tuple string items 0 of concatenation ", " of pathnames of files "unzip" of folders ("/bin";"/sbin";"/usr/sbin"; unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments)}"
-    wait {parameter "unzip"} __Download/apache-log4j-{{version}}-bin.zip -d __Download
+    wait {parameter "unzip"} __Download/apache-log4j-bin.zip -d __Download
     delete __appendfile
     appendfile #!/bin/sh
+	appendfile # log4j-core-2.x.jar replacement script {now as string}
 	appendfile # \cp is used to prevent the common 'cp -i' alias from being used
 	appendfile # -n is used to prevent clobbering destination.  We only want to backup the first, original version, of log4j-core
     appendfile {concatenation "%0a" of ("\cp -n %22" & it & "%22 %22" & it & "-disabled%22") of pathnames of files (unique values of (it as trimmed string) of preceding texts of firsts "," of following texts of firsts "vulnerability in " of lines whose (it as lowercase does not contain " (mitigated)" as lowercase) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite") whose (name of it starts with "log4j-core-2" and name of it ends with ".jar" and (size of it != {{log4j-core-size}} or sha256 of it != "{{log4j-core-sha256}}")) }
@@ -91,8 +94,9 @@ else
   
     delete ./replace_log4j.sh
     move __appendfile ./replace_log4j.sh
+	copy replace_log4j.sh "{pathname of folder "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite"}/replace_log4j-{id of action as string}.txt"
     wait {parameter "shell_bin"} -c "chmod +x ./replace_log4j.sh"
-    wait {parameter "shell_bin"} -c "./replace_log4j.sh"
+    wait {parameter "shell_bin"} -c "./replace_log4j.sh > '{pathname of folder "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite"}/replace_log4j-{id of action as string}_output.txt' 2>&1"
   endif
   
   // Check success - no un-fixed log4j-core-2.x.jar files remain.  Their sha hashes should be updated to reflect the 2.16.0 version

--- a/Apache/log4j2-replace-Win.bigfix.recipe.yaml
+++ b/Apache/log4j2-replace-Win.bigfix.recipe.yaml
@@ -5,6 +5,7 @@ Input:
   # Name: Short Name of the Software, No spaces, Example: "DBBrowserforSQLite"
   NAME: log4j2-scan
   DisplayName: log4j2-scan
+  BESFileName: Log4j2 Remediation - Replace log4j-core-2.x.jar with log4j-core-2.17.0.jar - Universal
 # MinimumVersion of AutoPkg - Should always be 2.3 (or higher once a new version is released)
 MinimumVersion: "2.3"
 ParentRecipe: com.github.jgstew.download.log4j2-bin
@@ -16,7 +17,7 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/BigFixPrefetchItem
     Arguments:
       prefetch_type: block
-      
+
   # `BigFixSetupTemplateDictionary` creates a dictionary to fill out a bigix content template
   #   If `SourceReleaseDate` is not provided, it will be set to today
   - Processor: com.github.jgstew.SharedProcessors/BigFixSetupTemplateDictionary
@@ -54,7 +55,7 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/log4j2-replace-Win.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/%NAME%.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/%BESFileName%.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`

--- a/Apache/log4j2-replace-Win.bigfix.recipe.yaml
+++ b/Apache/log4j2-replace-Win.bigfix.recipe.yaml
@@ -14,7 +14,9 @@ Process:
   # `BigFixPrefetchItem` takes the hashes from `URLDownloaderPython`
   #   Then it assembles them into a BigFix Prefetch Statement or Block
   - Processor: com.github.jgstew.SharedProcessors/BigFixPrefetchItem
-
+    Arguments:
+      prefetch_type: block
+      
   # `BigFixSetupTemplateDictionary` creates a dictionary to fill out a bigix content template
   #   If `SourceReleaseDate` is not provided, it will be set to today
   - Processor: com.github.jgstew.SharedProcessors/BigFixSetupTemplateDictionary

--- a/Logpresso/log4j2-scan-Linux-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Linux-run.bes.mustache
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>Run: {{DisplayName}} v{{version}} - {{TitleOS}}{{#64BitOnly}} (x64){{/64BitOnly}}</Title>
-		<Description><![CDATA[{{>Log4J2Scan-Description}}]]></Description>
+		<Title>Run: {{DisplayName}} v{{version}} - {{TitleOS}}{{#64BitOnly}} (x64){{/64BitOnly}}{{#remediate}} - WITH REMEDIATION{{/remediate}}</Title>
+		<Description><![CDATA[
+		{{>Description-CommunityTestStatement}}
+		</P>
+		{{>Log4J2Scan-Description-Links}}
+		</P>
+		{{>Log4J2Scan-Description}}
+		</P>
+		{{#remediate}}{{>Log4JScan-Description-Remediation}}{{/remediate}}
+		]]>		</Description>
 		<Relevance><![CDATA[{{{RelevanceOS}}}]]></Relevance>
 		{{#64BitOnly}}<Relevance><![CDATA["x86_64" = architecture of operating system]]></Relevance>{{/64BitOnly}}
-		<Relevance><![CDATA[not exists modification times whose(now - it < 1*day) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite"]]></Relevance>
 		<Category></Category>
 		<DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
 		<Source>{{DisplayName}}</Source>
@@ -50,10 +57,16 @@ run {parameter "shell_bin"} -c "chmod +x /tmp/log4j2-scan"
 
 // Run {{DisplayName}}:
 // WARNING: this attempts to exclude network shares, but might not be perfect.
-run {parameter "shell_bin"} -c "cd /tmp && ./log4j2-scan --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}'"
+run {parameter "shell_bin"} -c "cd /tmp && ./log4j2-scan --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} / > '{parameter "ListFile"}'"
+
+// Wait up to 30 seconds for the logfile to be created to check successful starupt
+parameter "StartTime"="{now}"
+pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
+// Check that an output log file has been created as an indicator that the scan has launched successfully
+continue if {exists file (parameter "ListFile") whose (modification time of it >= active start time of action)}
 
 // End]]></ActionScript>
-			<SuccessCriteria Option="OriginalRelevance"></SuccessCriteria>
+
 		</DefaultAction>
 	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 </BES>

--- a/Logpresso/log4j2-scan-Linux.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Linux.bigfix.recipe.yaml
@@ -40,8 +40,20 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%NAME%-Linux-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/%NAME%.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - Linux x64.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: "--force-fix"
+
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - Linux x64 - Remediate.bes"
+  
   - Processor: com.github.jgstew.SharedProcessors/BESImport

--- a/Logpresso/log4j2-scan-Mac.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Mac.bigfix.recipe.yaml
@@ -40,8 +40,21 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%DisplayName%-Linux-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/%NAME%.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - MacOS x64.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
+  
+  # Build "Remediation" version of fixlet
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: "--force-fix"
+
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - MacOS x64 - Remediate.bes"
+  
   - Processor: com.github.jgstew.SharedProcessors/BESImport

--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - Download JRE</Title>
-		<Description><![CDATA[{{>Log4J2Scan-Description}}
-		<P><H3>NOTE:</H3> This version of the scan fixlet downloads the JAR version of {{DisplayName}} as well as a temporary Java Runtime from Adoptium/AdoptOpenJDK to execute the scanner.</P>
-		]]></Description>
+		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - Download JRE{{#remediate}} - WITH REMEDIATION{{/remediate}}</Title>
+		<Description><![CDATA[
+		{{>Description-CommunityTestStatement}}
+		</P>
+		{{>Log4J2Scan-Description-Links}}
+		</P>
+		{{>Log4J2Scan-Description}}
+		</P>
+		{{#remediate}}{{>Log4JScan-Description-Remediation}}{{/remediate}}
+		<P>
+		<H3>NOTE:</H3> This version of the scan fixlet downloads the JAR version of {{DisplayName}} as well as a temporary Java Runtime from Adoptium/AdoptOpenJDK to execute the scanner.</P>
+		]]>		</Description>
 		<Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
 		<Relevance>windows of operating system or name of operating system as lowercase starts with "linux" or (if exists property "mac" of type "operating system" then mac of operating system else name of operating system as lowercase as lowercase starts with "mac")</Relevance>
 		<Category></Category>
@@ -145,7 +153,7 @@ copy __appendfile "{parameter "ExclusionFile"}"
 
 if {windows of operating system}
   // Execute scan
-  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config "{parameter "ExclusionFile"}"> "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
+  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config "{parameter "ExclusionFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
 
 elseif {(name of operating system as lowercase starts with "linux") or (if exists property "mac" of type "operating system" then mac of operating system else name of operating system as lowercase as lowercase starts with "mac")}
   // Get shell binary, should return /bin/sh in most cases:
@@ -153,14 +161,14 @@ elseif {(name of operating system as lowercase starts with "linux") or (if exist
 
   // Run log4j2-scan:
   // WARNING: this attempts to exclude network shares, but might not be perfect.
-  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
 
 else
   // Did not recognize the OS.  Adding more is on the roadmap.
   continue if {false}
 endif
 
-// Give 30 seconds for startup before checking
+// Wait up to 30 seconds for the logfile to be created to check successful starupt
 parameter "StartTime"="{now}"
 pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
 // Check that an output log file has been created as an indicator that the scan has launched successfully

--- a/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
@@ -29,8 +29,21 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%NAME%-Universal-JRE-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/%NAME%.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
+  
+  # Build "Remediation" version of fixlet
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: "--force-fix"
+
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - Remediate.bes"
+  
   - Processor: com.github.jgstew.SharedProcessors/BESImport

--- a/Logpresso/log4j2-scan-Universal-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-run.bes.mustache
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - System JRE</Title>
-		<Description><![CDATA[{{>Log4J2Scan-Description}}
+		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - System JRE{{#remediate}} - WITH REMEDIATION{{/remediate}}</Title>
+		<Description><![CDATA[
+		{{>Description-CommunityTestStatement}}
+		</P>
+		{{>Log4J2Scan-Description-Links}}
+		</P>
+		{{>Log4J2Scan-Description}}
+		</P>
+		{{#remediate}}{{>Log4JScan-Description-Remediation}}{{/remediate}}
+
 		<P><H3>NOTE:</H3> This version of the scan fixlet downloads the JAR version of {{DisplayName}}.  The system-default Java Runtime will be used.&nbsp; This requires the Java command to be present in the default system PATH variable.</P>
 		]]>		</Description>
 		<Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
@@ -81,14 +89,14 @@ copy __appendfile "{parameter "ExclusionFile"}"
 
 
 if {windows of operating system}
-  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & java -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config "{parameter "ExclusionFile"}"> "{parameter "ListFile"}""
+  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & java -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config "{parameter "ExclusionFile"}" {{remediate}} > "{parameter "ListFile"}""
 else // non-Windows operating system:
   // Get shell binary, should return /bin/sh in most cases:
   parameter "shell_bin" = "{  tuple string items 0 of concatenations ", " of ( pathnames of files "/bin/sh"; pathnames of files whose(name of it as lowercase = "sh" OR name of it as lowercase = "sh.exe") of (folders it) of unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments) }"
 
   // Run log4j2-scan:
   // WARNING: this attempts to exclude network shares, but might not be perfect.
-  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' && java -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}' / > '{parameter "ListFile"}'"
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' && java -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} / > '{parameter "ListFile"}'"
 endif
 
 // Give 30 seconds for startup before checking

--- a/Logpresso/log4j2-scan-Universal.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal.bigfix.recipe.yaml
@@ -29,8 +29,22 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%NAME%-Universal-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/%NAME%.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - Universal.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`
   - Processor: com.github.jgstew.SharedProcessors/BESImport
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: "--force-fix"
+
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - Universal - Remediate.bes"
+  
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
+
+

--- a/Logpresso/log4j2-scan-Win64-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Win64-run.bes.mustache
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>Run: {{DisplayName}} v{{version}} - Windows{{#64BitOnly}} (x64){{/64BitOnly}}</Title>
+		<Title>Run: {{DisplayName}} v{{version}} - Windows{{#64BitOnly}} (x64){{/64BitOnly}}{{#remediate}} - WITH REMEDIATION{{/remediate}}</Title>
 		<Description><![CDATA[
-This task will run {{DisplayName}} v{{version}} scanner.
+{{>Description-CommunityTestStatement}}
+		</P>
+		{{>Log4J2Scan-Description-Links}}
+		</P>
+		{{>Log4J2Scan-Description}}
+		</P>
+		{{#remediate}}{{>Log4JScan-Description-Remediation}}{{/remediate}}
+		<P>
 		]]>		</Description>
 		<Relevance>windows of operating system</Relevance>
 		{{#64BitOnly}}
 		<Relevance><![CDATA[x64 of operating system]]></Relevance>
 		{{/64BitOnly}}
-		<Relevance><![CDATA[not exists modification times whose(now - it < 1*day) of files "results-log4j2-scan.txt" of folders "BPS-Scans" of parent folders of parent folders of client folders of sites "actionsite"]]></Relevance>
 		<Category></Category>
 		<DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
 		<Source>{{DisplayName}}</Source>
@@ -62,10 +68,16 @@ delete "{parameter "ListFile"}"
 
 
 // Run:
-runhidden CMD /C {windows folder}\Temp\log4j2-scan.exe --scan-log4j1 --no-symlink --no-empty-report --drives {concatenations "," of unique values of (it as lowercase) of preceding texts of firsts ":" of names of drives whose (type of it = "DRIVE_FIXED")} > "{parameter "ListFile"}"
+runhidden CMD /C {windows folder}\Temp\log4j2-scan.exe --scan-log4j1 --no-symlink --no-empty-report --drives {concatenations "," of unique values of (it as lowercase) of preceding texts of firsts ":" of names of drives whose (type of it = "DRIVE_FIXED")}   {{remediate}} > "{parameter "ListFile"}"
+
+// Wait up to 30 seconds for the logfile to be created to check successful starupt
+parameter "StartTime"="{now}"
+pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
+// Check that an output log file has been created as an indicator that the scan has launched successfully
+continue if {exists file (parameter "ListFile") whose (modification time of it >= active start time of action)}
 
 // End]]></ActionScript>
-			<SuccessCriteria Option="OriginalRelevance"></SuccessCriteria>
+
 		</DefaultAction>
 	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 </BES>

--- a/Logpresso/log4j2-scan-Win64-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Win64-run.bes.mustache
@@ -4,7 +4,7 @@
 		<Title>Run: {{DisplayName}} v{{version}} - Windows{{#64BitOnly}} (x64){{/64BitOnly}}</Title>
 		<Description><![CDATA[
 This task will run {{DisplayName}} v{{version}} scanner.
-		]]></Description>
+		]]>		</Description>
 		<Relevance>windows of operating system</Relevance>
 		{{#64BitOnly}}
 		<Relevance><![CDATA[x64 of operating system]]></Relevance>
@@ -65,7 +65,7 @@ delete "{parameter "ListFile"}"
 runhidden CMD /C {windows folder}\Temp\log4j2-scan.exe --scan-log4j1 --no-symlink --no-empty-report --drives {concatenations "," of unique values of (it as lowercase) of preceding texts of firsts ":" of names of drives whose (type of it = "DRIVE_FIXED")} > "{parameter "ListFile"}"
 
 // End]]></ActionScript>
-      		<SuccessCriteria Option="OriginalRelevance"></SuccessCriteria>
+			<SuccessCriteria Option="OriginalRelevance"></SuccessCriteria>
 		</DefaultAction>
 	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 </BES>

--- a/Logpresso/log4j2-scan-Win64.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Win64.bigfix.recipe.yaml
@@ -28,7 +28,7 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%NAME%-Win64-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/%NAME%.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - Windows x64.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`
@@ -36,3 +36,16 @@ Process:
 
   # `BigFixActioner` creates an offer action from the imported BigFix Content
   - Processor: com.github.jgstew.SharedProcessors/BigFixActioner
+  
+  # Build "Remediation" version of fixlet
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: "--force-fix"
+
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - Windows x64 - Remediate.bes"
+  
+  - Processor: com.github.jgstew.SharedProcessors/BESImport


### PR DESCRIPTION
Note I haven't tested this in recipe form yet.
Added a new template for unzip in prefetch block so it doesn't try to use the Utility command in a prefetch block.
Tested my original version on Windows and Linux, will test in recipe form later today.