### PR TITLE
FIx working directories for all

### DIFF
--- a/.templates/.partials/Log4J2Scan-ActionFolder.mustache
+++ b/.templates/.partials/Log4J2Scan-ActionFolder.mustache
@@ -1,13 +1,6 @@
 // BES Client Folder Determination
-if {name of operating system as lowercase starts with "win"}
-    parameter "BPSFolder" = "{pathname of parent folder of client}\BPS-Scans\"
-else
-    parameter "BPSFolder" = "{(if (version of client >= "9" as version) then (pathname of parent folder of data folder of client) else (pathname of parent folder of parent folder of client folder of site "actionsite"))}/BPS-Scans/"
-endif
-
-if {not exists folder (parameter "BPSFolder")}
-    folder create "{parameter "BPSFolder"}"
-endif
+folder create "{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans"
+parameter "BPSFolder"="{pathname of folder "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"}{if windows of operating system then "\" else "/"}"
 
 parameter "ListFile"="{parameter "BPSFolder"}results-{{DisplayName}}.txt"
 parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"

--- a/Logpresso/log4j2-scan-Linux-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Linux-run.bes.mustache
@@ -39,25 +39,29 @@
 			<ActionScript MIMEType="application/x-Fixlet-Windows-Shell"><![CDATA[
 //parameter "exclusionlist" is provided in the Description tab
 // Download {{DisplayName}}:
+begin prefetch block
 {{{prefetch}}}
+end prefetch block
+
+{{>Log4J2Scan-ActionFolder}}
 
 // Get shell binary, should return /bin/sh in most cases:
 parameter "shell_bin" = "{ tuple string items 0 of concatenations ", " of ( pathnames of files whose(name of it as lowercase = "sh" OR name of it as lowercase = "sh.exe") of (folders it) of unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it; (if (windows of operating system) then (x64 variables "PATH" of it) else NOTHINGS) ) of environments ; it) of "/bin/sh" }"
 
 // Delete destination of next command if applicable
-delete /tmp/log4j2-scan
+delete "{parameter "BPSFolder"}log4j2-scan"
 
 // TODO: Does this command work on Linux and Unix? Does this binary work on Unix?
-wait tar -zxf __Download/{{file_name}} -C /tmp
+wait tar -zxf __Download/{{file_name}} -C "{parameter "BPSFolder"}"
 
-{{>Log4J2Scan-ActionFolder}}
+
 
 // Set to log4j2-scan executable
-run {parameter "shell_bin"} -c "chmod +x /tmp/log4j2-scan"
+run {parameter "shell_bin"} -c "chmod +x '{parameter "BPSFolder"}log4j2-scan'"
 
 // Run {{DisplayName}}:
 // WARNING: this attempts to exclude network shares, but might not be perfect.
-run {parameter "shell_bin"} -c "cd /tmp && ./log4j2-scan --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} / > '{parameter "ListFile"}'"
+run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' && ./log4j2-scan --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} / > '{parameter "ListFile"}'"
 
 // Wait up to 30 seconds for the logfile to be created to check successful starupt
 parameter "StartTime"="{now}"

--- a/Logpresso/log4j2-scan-Linux.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Linux.bigfix.recipe.yaml
@@ -17,7 +17,8 @@ Process:
   # `BigFixPrefetchItem` takes the hashes from `URLDownloaderPython`
   #   Then it assembles them into a BigFix Prefetch Statement or Block
   - Processor: com.github.jgstew.SharedProcessors/BigFixPrefetchItem
-
+    Arguments:
+      prefetch_type: block
   # `BigFixSetupTemplateDictionary` creates a dictionary to fill out a bigix content template
   #   If `SourceReleaseDate` is not provided, it will be set to today
   - Processor: com.github.jgstew.SharedProcessors/BigFixSetupTemplateDictionary

--- a/Logpresso/log4j2-scan-Mac.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Mac.bigfix.recipe.yaml
@@ -17,7 +17,9 @@ Process:
   # `BigFixPrefetchItem` takes the hashes from `URLDownloaderPython`
   #   Then it assembles them into a BigFix Prefetch Statement or Block
   - Processor: com.github.jgstew.SharedProcessors/BigFixPrefetchItem
-
+    Arguments:
+      prefetch_type: block
+      
   # `BigFixSetupTemplateDictionary` creates a dictionary to fill out a bigix content template
   #   If `SourceReleaseDate` is not provided, it will be set to today
   - Processor: com.github.jgstew.SharedProcessors/BigFixSetupTemplateDictionary

--- a/Logpresso/log4j2-scan-Mac.download.recipe.yaml
+++ b/Logpresso/log4j2-scan-Mac.download.recipe.yaml
@@ -4,7 +4,7 @@ Identifier: com.github.jgstew.download.log4j2-scan-Mac
 Input:
   NAME: log4j2-scan-mac
   # TYPE must be `zip` or `7z` or `tar.gz`
-  TYPE: tar.gz
+  TYPE: zip
   OS: -darwin
 MinimumVersion: "2.3"
 ParentRecipe: com.github.jgstew.download.log4j2-scan-Win64

--- a/Logpresso/log4j2-scan-Win64-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Win64-run.bes.mustache
@@ -41,24 +41,27 @@
 			</Description>
 			<ActionScript MIMEType="application/x-Fixlet-Windows-Shell"><![CDATA[
 // Download {{DisplayName}}:
+begin prefetch block
 {{{prefetch}}}
-{{>ActionPrefetchUnzipExe}}
 
-// delete any existing copy if applicable
-delete {windows folder}\Temp\log4j2-scan.exe
+{{>ActionPrefetchBlockUnzipExe}}
+collect prefetch items
+end prefetch block
 
-waithidden __Download\unzip.exe -o "{pathname of files "{{file_name}}" of folders "__Download" of client folder of current site}" -d {windows folder}\Temp
+if {exists file "__Download\unzip.exe"}
+  utility __Download/unzip.exe
+endif
+
 
 // BES Client Folder Determination
-if {name of operating system as lowercase starts with "win"}
-    parameter "BPSFolder" = "{pathname of parent folder of client}\BPS-Scans\"
-else
-    parameter "BPSFolder" = "{(if (version of client >= "9" as version) then (pathname of parent folder of data folder of client) else (pathname of parent folder of parent folder of client folder of site "actionsite"))}/BPS-Scans/"
-endif
+folder create "{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans"
+parameter "BPSFolder"="{pathname of folder "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"}{if windows of operating system then "\" else "/"}"
 
-if {not exists folder (parameter "BPSFolder")}
-    folder create "{parameter "BPSFolder"}"
-endif
+// delete any existing copy if applicable
+delete "{parameter "BPSFolder"}log4j2-scan.exe"
+
+//Unzip.exe doesn't deal with the trailing slash on folder name
+waithidden __Download\unzip.exe -o "{pathname of files "{{file_name}}" of folders "__Download" of client folder of current site}" -d "{pathname of folder (parameter "BPSFolder")}"
 
 parameter "ListFile"="{parameter "BPSFolder"}results-{{DisplayName}}.txt"
 
@@ -68,7 +71,7 @@ delete "{parameter "ListFile"}"
 
 
 // Run:
-runhidden CMD /C {windows folder}\Temp\log4j2-scan.exe --scan-log4j1 --no-symlink --no-empty-report --drives {concatenations "," of unique values of (it as lowercase) of preceding texts of firsts ":" of names of drives whose (type of it = "DRIVE_FIXED")}   {{remediate}} > "{parameter "ListFile"}"
+runhidden CMD /C ""{parameter "BPSFolder"}log4j2-scan.exe" --scan-log4j1 --no-symlink --no-empty-report --drives {concatenations "," of unique values of (it as lowercase) of preceding texts of firsts ":" of names of drives whose (type of it = "DRIVE_FIXED")}   {{remediate}} > "{parameter "ListFile"}""
 
 // Wait up to 30 seconds for the logfile to be created to check successful starupt
 parameter "StartTime"="{now}"

--- a/Logpresso/log4j2-scan-Win64.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Win64.bigfix.recipe.yaml
@@ -15,7 +15,9 @@ Process:
   # `BigFixPrefetchItem` takes the hashes from `URLDownloaderPython`
   #   Then it assembles them into a BigFix Prefetch Statement or Block
   - Processor: com.github.jgstew.SharedProcessors/BigFixPrefetchItem
-
+    Arguments:
+      prefetch_type: block
+      
   # `BigFixSetupTemplateDictionary` creates a dictionary to fill out a bigix content template
   #   If `SourceReleaseDate` is not provided, it will be set to today
   - Processor: com.github.jgstew.SharedProcessors/BigFixSetupTemplateDictionary


### PR DESCRIPTION
Fixed working directories so backup files end up in BPS-Scans.
The method I'm using to find the BPS-Scans folder matches the JAR-based scans, but requires using a prefetch block, so we don't get an evaluation substitution error trying to get the pathname of BPS-Scans during prefetch, before we've created the folder.
