### PR TITLE
Jason-zip-fixes

### DIFF
--- a/.templates/.partials/Log4J2Scan-Action-ExcludeList.mustache
+++ b/.templates/.partials/Log4J2Scan-Action-ExcludeList.mustache
@@ -1,0 +1,24 @@
+// Delete previous items
+delete "{parameter "ListFile"}"
+delete __appendfile
+delete "{parameter "ExclusionFile"}"
+
+//build exclusions list
+appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of (unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | ""))}
+
+appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of ("/mnt";"/dev";"/cdrom")}
+
+if {exists properties "type" of types "filesystem"}
+ appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of mount points of filesystems whose (type of it != "DRIVE_FIXED" ) }
+endif
+
+//mac-specific
+if {exists properties "type" of types "volume"}
+ appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of (it as string) of volumes whose (type of it != "DRIVE_FIXED" ) }
+endif
+
+if {exists properties "filesystem type" of types "filesystem"}
+ appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of mount points of filesystems whose (filesystem type of it is contained by set of ("cgroup";"cifs";"nfs";"nfs3";"nfs4";"cgroup2";"sysfs";"proc";"cpuset") ) }
+endif
+
+copy __appendfile "{parameter "ExclusionFile"}"

--- a/.templates/.partials/Log4J2Scan-Description-ExclusionTable.mustache
+++ b/.templates/.partials/Log4J2Scan-Description-ExclusionTable.mustache
@@ -1,4 +1,3 @@
-This task will run {{ DisplayName }} v{{ version }} scanner.<br />
 <TABLE>
   <TBODY>
     <TR>

--- a/.templates/.partials/Log4J2Scan-Description-Links.mustache
+++ b/.templates/.partials/Log4J2Scan-Description-Links.mustache
@@ -17,3 +17,4 @@
 <P><BR>&nbsp;(be sure to check for the latest version).</P>
 <P>For the latest details and discussion of this content, please see <A href="https://forum.bigfix.com/t/log4j-cve-2021-44228-cve-2021-45046-summary-page/40222">https://forum.bigfix.com/t/log4j-cve-2021-44228-cve-2021-45046-summary-page/40222</A></P>
 <P>&nbsp;</P>
+This task will run {{ DisplayName }} v{{ version }} scanner.<br />

--- a/.templates/.partials/Log4JScan-Description-Undo-Remediation.mustache
+++ b/.templates/.partials/Log4JScan-Description-Undo-Remediation.mustache
@@ -1,0 +1,3 @@
+<P><H3>This Action will restore the original versions of JAR files that were previously remediated by a LogPresso scan.</H3></P>
+After restoring the original JAR file versions, a new Scan should be executed to determine the new vulnerability status.<br>
+A new Remediation may then be executed, potentially excluding the paths of whatever application fails to function after remediation.<br>

--- a/.templates/.partials/Log4JScan-Description-Undo-Remediation.mustache
+++ b/.templates/.partials/Log4JScan-Description-Undo-Remediation.mustache
@@ -1,3 +1,4 @@
 <P><H3>This Action will restore the original versions of JAR files that were previously remediated by a LogPresso scan.</H3></P>
 After restoring the original JAR file versions, a new Scan should be executed to determine the new vulnerability status.<br>
 A new Remediation may then be executed, potentially excluding the paths of whatever application fails to function after remediation.<br>
+<H3>Files that were remediated by ALL prior scans are restored</H3><br>

--- a/.templates/.partials/Log4j2Scan-Description-OfficialVersion.mustache
+++ b/.templates/.partials/Log4j2Scan-Description-OfficialVersion.mustache
@@ -1,0 +1,18 @@
+<P>This task will: </P>
+<UL>
+	<LI>Download a platform specific JRE or JDK </LI>
+	<LI>Download a log4j-scan utility JAR file from Logpresso </LI>
+	<LI>Run the log4j-scan utility JAR with the platform specific JRE or JDK </LI>
+	<LI>Save results to a file. Results available in an analysis </LI>
+	<LI>Delete the platform specific JRE or JDK when the scan is completed. </LI>
+</UL>
+<P>The following platforms are currently excluded: </P>
+<UL>
+	<LI>Windows 2012 or older, Windows 8 or older </LI>
+	<LI>Linux Z and Linux PowerPC Big Endian </LI>
+	<LI>HP-UX </LI>
+</UL>
+<P>The scan should not be deployed all at once on all systems due to potential impact to shared network and disk resources. </P>
+<P>The scanner will try to avoid common network file shares and will not follow symlinks to help prevent common potential problems, but this is not a guarantee that all cases are covered. If you know you need to exclude specific paths, those can be added in the field below. </P>
+<P>A BigFix task that can also do mitigation of Log4j vulnerabilities using the same technology is available if you contact us or unofficially through the BigFix community.</P>
+<br />

--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -1,20 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - Download JRE{{#remediate}} - WITH REMEDIATION{{/remediate}}</Title>
+		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - Download JRE{{#scan}} - SCAN only{{/scan}}{{#remediate}} - WITH REMEDIATION{{/remediate}}{{#undo-remediate}} - UNDO REMEDIATION{{/undo-remediate}}</Title>
 		<Description><![CDATA[
 		{{>Description-CommunityTestStatement}}
 		</P>
 		{{>Log4J2Scan-Description-Links}}
 		</P>
+		{{#scan}}
 		{{>Log4J2Scan-Description}}
+		{{/scan}}
+		{{#remediate}}
+		{{>Log4J2Scan-Description}}
+		{{/remediate}}
 		</P>
 		{{#remediate}}{{>Log4JScan-Description-Remediation}}{{/remediate}}
+		{{#undo-remediate}}{{>Log4JScan-Description-Undo-Remediation}}{{/undo-remediate}}
 		<P>
 		<H3>NOTE:</H3> This version of the scan fixlet downloads the JAR version of {{DisplayName}} as well as a temporary Java Runtime from Adoptium/AdoptOpenJDK to execute the scanner.</P>
 		]]>		</Description>
 		<Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
 		<Relevance><![CDATA[( if (name of operating system as lowercase contains "win") then (version of operating system >= "6.3") else TRUE ) AND ( if (name of operating system as lowercase contains "linux") AND ((architecture of it = "s390x") of operating system OR (architecture of it = "ppc64") of operating system) then FALSE else TRUE ) AND (name of operating system does not start with "HP-UX")]]></Relevance>
+		{{#undo-remediate}}<Relevance><![CDATA[exists find files "log4j2_scan_backup_*.zip" of folders "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"]]></Relevance> {{/undo-remediate}}
 		<Category></Category>
 		<DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
 		<Source>{{DisplayName}}</Source>
@@ -64,16 +71,32 @@ if {exists files "__Download/jre.tar.gz"}
 endif
 
 folder create "{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans"
+
+// 'folder delete' fails in certain symlink situations - as used by some JREs.  Use OS commands rather tha ActionScript to remove it.
+//folder delete "{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans/jre"
+
 folder create "{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans/jre"
 
 parameter "BPSFolder"="{pathname of folder "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"}{if windows of operating system then "\" else "/"}"
+parameter "JREFolder"="{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans/jre"
+{{#scan}}
 parameter "ListFile"="{parameter "BPSFolder"}results-log4j2-scan.txt"
 parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
-parameter "JREFolder"="{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans/jre"
+{{/scan}}
+{{#remediate}}
+parameter "ListFile"="{parameter "BPSFolder"}results-log4j2-scan.txt"
+parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
+{{/remediate}}
+{{#undo-remediate}}
+parameter "RestoreListFile"="{parameter "BPSFolder"}restore-log4j2-scan.txt"
+{{/undo-remediate}}
+
 
 // --- Begin JRE extraction
 if {windows of operating system}
-  waithidden __Download/unzip.exe "__Download/jre.zip" -d "{parameter "JREFolder"}"
+  waithidden __Download/unzip.exe -oq "__Download/jre.zip" -d "{parameter "JREFolder"}"
+  delete "__Download/jre.zip"
+  delete "__Download/unzip.exe"
 
 
 else
@@ -100,6 +123,8 @@ else
 
     wait {parameter "unzip"} "__Download/jre.tar.gz"
 	wait {parameter "tar" } -xf "__Download/jre.tar" -C "{parameter "JREFolder"}"
+	delete "__Download/jre.tar.gz"
+	delete "__Download/jre.tar"
 
   elseif {exists match (regex "SunOS") of name of operating system}
     // SunOS extraction for i386 or Sparc
@@ -109,11 +134,15 @@ else
 	// SunOS version of tar does not support specifying output folder, so unzip in-place and then use shell redirection to relocate the untar
 	wait {parameter "unzip"} "__Download/jre.tar.gz"
 	wait {parameter "shell_bin"} -c "( cd '{parameter "BPSFolder"}jre' && tar xf - ) < __Download/jre.tar"
+	delete "__Download/jre.tar.gz"
+	delete "__Download/jre.tar"
 
   else
     // Unless otherwise specified, our UNIX/Linux variant version of 'tar' should support both decompress and output folder spec
     // extract temporary JRE
     wait {parameter "tar"} -xzvf "__Download/jre.tar.gz" -C "{parameter "JREFolder"}"
+	delete "__Download/jre.tar.gz"
+	delete "__Download/jre.tar"
   endif
 endif
 
@@ -132,50 +161,76 @@ endif
 // Copy the scanner JAR file to client folder
 copy __Download/logpresso-log4j2-scan.jar "{parameter "BPSFolder"}/logpresso-log4j2-scan.jar"
 
-// Delete previous items
-delete "{parameter "ListFile"}"
-delete __appendfile
-delete "{parameter "ExclusionFile"}"
-
-//build exclusions list
-appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of (unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | ""))}
-
-appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of ("/mnt";"/dev";"/cdrom")}
-
-if {exists properties "type" of types "filesystem"}
- appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of mount points of filesystems whose (type of it != "DRIVE_FIXED" ) }
-endif
-
-//mac-specific
-if {exists properties "type" of types "volume"}
- appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of (it as string) of volumes whose (type of it != "DRIVE_FIXED" ) }
-endif
-
-if {exists properties "filesystem type" of types "filesystem"}
- appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of mount points of filesystems whose (filesystem type of it is contained by set of ("cgroup";"cifs";"nfs";"nfs3";"nfs4";"cgroup2";"sysfs";"proc";"cpuset") ) }
-endif
-
-copy __appendfile "{parameter "ExclusionFile"}"
+{{#scan}}{{>Log4J2Scan-Action-ExcludeList}}{{/scan}}
+{{#remediate}}{{>Log4J2Scan-Action-ExcludeList}}{{/remediate}}
 
 if {windows of operating system}
   // Execute scan
+  {{#scan}}
   runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
+  {{/scan}}
+  {{#remediate}}
+  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
+  {{/remediate}}
+  {{#undo-remediate}}
+  delete __appendfile
+  appendfile cd "{parameter "BPSFolder"}"
+  appendfile del /q "{parameter "RestoreListFile"}"
+  appendfile {concatenation "%0d%0a" of ("%22" & parameter "Java_bin" & "%22 -jar %22" & parameter "BPSFolder" & "logpresso-log4j2-scan.jar%22  --restore %22" & it & "%22 >> %22" & parameter "RestoreListFile" & "%22 2>&1"; "echo move /Y %22" & it & "%22 %22" & it & ".restored%22") of pathnames of find files "log4j2_scan_backup_*.zip" of folders (parameter "BPSFolder")}
+  appendfile rd /s /q "{parameter "JREFolder"}"
+ 
+  delete log4j-restore.cmd
+  move __appendfile log4j-restore.cmd
+  waithidden cmd.exe /c log4j-restore.cmd
 
+  {{/undo-remediate}}
 else
-
-  // Run log4j2-scan:
+  {{#scan}}
+  // Run log4j2-scan scan-only:
   // WARNING: this attempts to exclude network shares, but might not be perfect.
   run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
-
+  {{/scan}}
+  {{#remediate}}
+  // Run log4j2-scan with remediation:
+  // WARNING: this attempts to exclude network shares, but might not be perfect.
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
+  {{/remediate}}
+  {{#undo-remediate}}
+  delete __appendfile
+  appendfile #!/bin/sh
+  appendfile cd '{parameter "BPSFolder"}' 
+  appendfile rm -f "{parameter "RestoreListFile"}"
+  appendfile {concatenation "%0a" of ("%22" & parameter "Java_bin" & "%22 -jar %22" & parameter "BPSFolder" & "logpresso-log4j2-scan.jar%22  --restore %22" & it & "%22 >> %22" & parameter "RestoreListFile" & "%22 2>&1 "; "echo mv -f %22" & it & "%22 %22" & it & ".restored%22") of pathnames of find files "log4j2_scan_backup_*.zip" of folders (parameter "BPSFolder")}
+  appendfile rm -rf '{parameter "JREFolder"}'
+  delete log4j-restore.sh
+  move __appendfile log4j-restore.sh
+  wait chmod +x log4j-restore.sh
+  wait {parameter "shell_bin"} ./log4j-restore.sh
+  {{/undo-remediate}}
 endif
 
-// Wait up to 30 seconds for the logfile to be created to check successful starupt
+
+ {{#scan}}
+// Wait up to 30 seconds for the logfile to be created to check successful startup
 parameter "StartTime"="{now}"
 pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
 // Check that an output log file has been created as an indicator that the scan has launched successfully
 continue if {exists file (parameter "ListFile") whose (modification time of it >= active start time of action)}
+ {{/scan}}
 
-{{#remediate}}action requires restart{{/remediate}}
+ {{#remediate}}
+// Wait up to 30 seconds for the logfile to be created to check successful startup
+parameter "StartTime"="{now}"
+pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
+// Check that an output log file has been created as an indicator that the scan has launched successfully
+continue if {exists file (parameter "ListFile") whose (modification time of it >= active start time of action)}
+action requires restart
+ {{/remediate}}
+
+{{#undo-remediate}}
+continue if {exists file (parameter "RestoreListFile") whose (modification time of it >= active start time of action)}
+action requires restart
+{{/undo-remediate}}
 
 // End]]></ActionScript>
 		</DefaultAction>

--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -186,7 +186,7 @@ else
   // Run log4j2-scan scan or remediation:
   // WARNING: this attempts to exclude network shares, but might not be perfect.
   delete "{parameter "ReportJSONFile"}"
-  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --silent --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}' --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --silent --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}' --report-json --report-path '{parameter "ReportJSONFile"}' {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
   {{/scan_or_remediate}}
   {{#undo-remediate}}
   delete __appendfile

--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -43,7 +43,7 @@
 			<Value>01:00:00</Value>
 		</MIMEField>
 		<Domain>BESC</Domain>
-		<DefaultAction ID="Action1">
+		<{{#scan}}DefaultAction{{/scan}}{{^scan}}Action{{/scan}} ID="Action1">
 			<Description>
 				<PreLink>Click </PreLink>
 				<Link>here</Link>
@@ -240,6 +240,6 @@ action requires restart
 {{/undo-remediate}}
 
 // End]]></ActionScript>
-		</DefaultAction>
+		</{{#scan}}DefaultAction{{/scan}}{{^scan}}Action{{/scan}} >
 	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 </BES>

--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -1,55 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
-	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - Download JRE{{#scan}} - SCAN only{{/scan}}{{#remediate}} - WITH REMEDIATION{{/remediate}}{{#undo-remediate}} - UNDO REMEDIATION{{/undo-remediate}}</Title>
-		<Description><![CDATA[
+  <{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
+    <Title>Run: {{DisplayName}} v{{version}} - Universal JAR - Download JRE{{#scan}} - SCAN only{{/scan}}{{#remediate}} - WITH REMEDIATION{{/remediate}}{{#undo-remediate}} - UNDO REMEDIATION{{/undo-remediate}}{{#communityversion}} - Community Version{{/communityversion}}</Title>
+    <Description><![CDATA[
+    {{#communityversion}}
 		{{>Description-CommunityTestStatement}}
 		</P>
 		{{>Log4J2Scan-Description-Links}}
 		</P>
-		{{#scan}}
-		{{>Log4J2Scan-Description}}
-		{{/scan}}
-		{{#remediate}}
-		{{>Log4J2Scan-Description}}
-		{{/remediate}}
+    {{/communityversion}}
+    {{^communityversion}}
+    {{>Log4j2Scan-Description-OfficialVersion}}
+    {{/communityversion}}
+		{{#scan_or_remediate}}
+		{{>Log4J2Scan-Description-ExclusionTable}}
+		{{/scan_or_remediate}}
 		</P>
 		{{#remediate}}{{>Log4JScan-Description-Remediation}}{{/remediate}}
 		{{#undo-remediate}}{{>Log4JScan-Description-Undo-Remediation}}{{/undo-remediate}}
 		<P>
 		<H3>NOTE:</H3> This version of the scan fixlet downloads the JAR version of {{DisplayName}} as well as a temporary Java Runtime from Adoptium/AdoptOpenJDK to execute the scanner.</P>
-		]]>		</Description>
-		<Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
-		<Relevance><![CDATA[( if (name of operating system as lowercase contains "win") then (version of operating system >= "6.3") else TRUE ) AND ( if (name of operating system as lowercase contains "linux") AND ((architecture of it = "s390x") of operating system OR (architecture of it = "ppc64") of operating system) then FALSE else TRUE ) AND (name of operating system does not start with "HP-UX")]]></Relevance>
+		]]>    </Description>
+    <Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
+    <Relevance><![CDATA[( if (name of operating system as lowercase contains "win") then (version of operating system >= "6.3") else TRUE ) AND ( if (name of operating system as lowercase contains "linux") AND ((architecture of it = "s390x") of operating system OR (architecture of it = "ppc64") of operating system) then FALSE else TRUE ) AND (name of operating system does not start with "HP-UX")]]></Relevance>
 		{{#undo-remediate}}<Relevance><![CDATA[exists find files "log4j2_scan_backup_*.zip" of folders "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"]]></Relevance> {{/undo-remediate}}
-		<Category></Category>
-		<DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
-		<Source>{{DisplayName}}</Source>
-		<SourceID></SourceID>
-		<SourceReleaseDate>{{SourceReleaseDate}}</SourceReleaseDate>
-		<SourceSeverity></SourceSeverity>
-		<CVENames></CVENames>
-		<SANSID></SANSID>
-		<MIMEField>
-			<Name>action-ui-metadata</Name>
-			<Value>{ {{#version}}"version":"{{version}}",{{/version}}"size":{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}{{^patch}}{{#icon_base64}},"icon":"data:{{icon_type}}{{^icon_type}}image/png{{/icon_type}};base64,{{icon_base64}}"{{/icon_base64}}{{/patch}} }</Value>
-		</MIMEField>
-		<MIMEField>
-			<Name>x-fixlet-modification-time</Name>
-			<Value>{{x-fixlet-modification-time}}</Value>
-		</MIMEField>
-		<MIMEField>
-			<Name>x-relevance-evaluation-period</Name>
-			<Value>01:00:00</Value>
-		</MIMEField>
-		<Domain>BESC</Domain>
-		<{{#scan}}DefaultAction{{/scan}}{{^scan}}Action{{/scan}} ID="Action1">
-			<Description>
-				<PreLink>Click </PreLink>
-				<Link>here</Link>
-				<PostLink> to run {{DisplayName}} v{{version}}.</PostLink>
-			</Description>
-			<ActionScript MIMEType="application/x-Fixlet-Windows-Shell"><![CDATA[
+    <Category></Category>
+    <DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
+    <Source>{{DisplayName}}</Source>
+    <SourceID></SourceID>
+    <SourceReleaseDate>{{SourceReleaseDate}}</SourceReleaseDate>
+    <SourceSeverity></SourceSeverity>
+    <CVENames></CVENames>
+    <SANSID></SANSID>
+    <MIMEField>
+      <Name>action-ui-metadata</Name>
+      <Value>{ {{#version}}"version":"{{version}}",{{/version}}"size":{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}{{^patch}}{{#icon_base64}},"icon":"data:{{icon_type}}{{^icon_type}}image/png{{/icon_type}};base64,{{icon_base64}}"{{/icon_base64}}{{/patch}} }</Value>
+    </MIMEField>
+    <MIMEField>
+      <Name>x-fixlet-modification-time</Name>
+      <Value>{{x-fixlet-modification-time}}</Value>
+    </MIMEField>
+    <MIMEField>
+      <Name>x-relevance-evaluation-period</Name>
+      <Value>01:00:00</Value>
+    </MIMEField>
+    <Domain>BESC</Domain>
+    <{{#scan}}DefaultAction{{/scan}}{{^scan}}Action{{/scan}} ID="Action1">
+      <Description>
+        <PreLink>Click </PreLink>
+        <Link>here</Link>
+        <PostLink> to run {{DisplayName}} v{{version}}.</PostLink>
+      </Description>
+      <ActionScript MIMEType="application/x-Fixlet-Windows-Shell"><![CDATA[
 //parameter "exclusionlist" is provided in the Description tab
 begin prefetch block
 	// Download {{DisplayName}}:
@@ -78,17 +80,12 @@ folder create "{pathname of parent folder of parent folder of client folder of s
 folder create "{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans/jre"
 
 parameter "BPSFolder"="{pathname of folder "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"}{if windows of operating system then "\" else "/"}"
-parameter "JREFolder"="{pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans/jre"
-{{#scan}}
+parameter "JREFolder"="{pathname of folder "jre" of folder "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"}"
+{{#scan_or_remediate}}
 parameter "ListFile"="{parameter "BPSFolder"}results-log4j2-scan.txt"
 parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
 parameter "ReportJSONFile"="{parameter "BPSFolder"}log4j2-report.json"
-{{/scan}}
-{{#remediate}}
-parameter "ListFile"="{parameter "BPSFolder"}results-log4j2-scan.txt"
-parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
-parameter "ReportJSONFile"="{parameter "BPSFolder"}log4j2-report.json"
-{{/remediate}}
+{{/scan_or_remediate}}
 {{#undo-remediate}}
 parameter "RestoreListFile"="{parameter "BPSFolder"}restore-log4j2-scan.txt"
 {{/undo-remediate}}
@@ -164,19 +161,14 @@ endif
 // Copy the scanner JAR file to client folder
 copy __Download/logpresso-log4j2-scan.jar "{parameter "BPSFolder"}/logpresso-log4j2-scan.jar"
 
-{{#scan}}{{>Log4J2Scan-Action-ExcludeList}}{{/scan}}
-{{#remediate}}{{>Log4J2Scan-Action-ExcludeList}}{{/remediate}}
+{{#scan_or_remediate}}{{>Log4J2Scan-Action-ExcludeList}}{{/scan_or_remediate}}
 
 if {windows of operating system}
   // Execute scan
-  {{#scan}}
+  {{#scan_or_remediate}}
   delete "{parameter "ReportJSONFile"}"
-  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
-  {{/scan}}
-  {{#remediate}}
-  delete "{parameter "ReportJSONFile"}"
-  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
-  {{/remediate}}
+  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --silent --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
+  {{/scan_or_remediate}}
   {{#undo-remediate}}
   delete __appendfile
   appendfile cd "{parameter "BPSFolder"}"
@@ -190,18 +182,12 @@ if {windows of operating system}
 
   {{/undo-remediate}}
 else
-  {{#scan}}
-  // Run log4j2-scan scan-only:
+  {{#scan_or_remediate}}
+  // Run log4j2-scan scan or remediation:
   // WARNING: this attempts to exclude network shares, but might not be perfect.
   delete "{parameter "ReportJSONFile"}"
-  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}' --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
-  {{/scan}}
-  {{#remediate}}
-  // Run log4j2-scan with remediation:
-  // WARNING: this attempts to exclude network shares, but might not be perfect.
-  delete "{parameter "ReportJSONFile"}"
-  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}' --report-json --report-path "{parameter "ReportJSONFile"}"  {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
-  {{/remediate}}
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --silent --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}' --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
+  {{/scan_or_remediate}}
   {{#undo-remediate}}
   delete __appendfile
   appendfile #!/bin/sh
@@ -217,29 +203,22 @@ else
 endif
 
 
- {{#scan}}
+{{#scan_or_remediate}}
 // Wait up to 30 seconds for the logfile to be created to check successful startup
 parameter "StartTime"="{now}"
 pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
 // Check that an output log file has been created as an indicator that the scan has launched successfully
 continue if {exists file (parameter "ListFile") whose (modification time of it >= active start time of action)}
- {{/scan}}
-
- {{#remediate}}
-// Wait up to 30 seconds for the logfile to be created to check successful startup
-parameter "StartTime"="{now}"
-pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
-// Check that an output log file has been created as an indicator that the scan has launched successfully
-continue if {exists file (parameter "ListFile") whose (modification time of it >= active start time of action)}
+{{#remediate}}
 action requires restart
- {{/remediate}}
-
+{{/remediate}}
+{{/scan_or_remediate}}
 {{#undo-remediate}}
 continue if {exists file (parameter "RestoreListFile") whose (modification time of it >= active start time of action)}
 action requires restart
 {{/undo-remediate}}
 
 // End]]></ActionScript>
-		</{{#scan}}DefaultAction{{/scan}}{{^scan}}Action{{/scan}} >
-	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
+    </{{#scan}}DefaultAction{{/scan}}{{^scan}}Action{{/scan}}>
+  </{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 </BES>

--- a/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-JRE-run.bes.mustache
@@ -82,10 +82,12 @@ parameter "JREFolder"="{pathname of parent folder of parent folder of client fol
 {{#scan}}
 parameter "ListFile"="{parameter "BPSFolder"}results-log4j2-scan.txt"
 parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
+parameter "ReportJSONFile"="{parameter "BPSFolder"}log4j2-report.json"
 {{/scan}}
 {{#remediate}}
 parameter "ListFile"="{parameter "BPSFolder"}results-log4j2-scan.txt"
 parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
+parameter "ReportJSONFile"="{parameter "BPSFolder"}log4j2-report.json"
 {{/remediate}}
 {{#undo-remediate}}
 parameter "RestoreListFile"="{parameter "BPSFolder"}restore-log4j2-scan.txt"
@@ -156,6 +158,7 @@ continue if {exists file (parameter "Java_bin")}
 // Setup logpresso-log4j2-scan.jar
 if { exists files "logpresso-log4j2-scan.jar" of folders (parameter "BPSFolder")}
   delete "{pathname of file "logpresso-log4j2-scan.jar" of folder (parameter "BPSFolder")}"
+  
 endif
 
 // Copy the scanner JAR file to client folder
@@ -167,10 +170,12 @@ copy __Download/logpresso-log4j2-scan.jar "{parameter "BPSFolder"}/logpresso-log
 if {windows of operating system}
   // Execute scan
   {{#scan}}
-  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
+  delete "{parameter "ReportJSONFile"}"
+  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
   {{/scan}}
   {{#remediate}}
-  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
+  delete "{parameter "ReportJSONFile"}"
+  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & "{parameter "Java_bin"}" -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} > "{parameter "ListFile"}" & rd /s /q "{parameter "JREFolder"}""
   {{/remediate}}
   {{#undo-remediate}}
   delete __appendfile
@@ -188,12 +193,14 @@ else
   {{#scan}}
   // Run log4j2-scan scan-only:
   // WARNING: this attempts to exclude network shares, but might not be perfect.
-  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
+  delete "{parameter "ReportJSONFile"}"
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}' --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
   {{/scan}}
   {{#remediate}}
   // Run log4j2-scan with remediation:
   // WARNING: this attempts to exclude network shares, but might not be perfect.
-  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
+  delete "{parameter "ReportJSONFile"}"
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; '{parameter "Java_bin"}' -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}' --report-json --report-path "{parameter "ReportJSONFile"}"  {{remediate}} /  > '{parameter "ListFile"}' ; rm -rf '{parameter "JREFolder"}'"
   {{/remediate}}
   {{#undo-remediate}}
   delete __appendfile

--- a/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
@@ -23,6 +23,14 @@ Process:
 
   - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppendInput
 
+  # Build "official" versions of each, without the Community Test descriptions
+  #####
+  # "scan_or_remediate" key is common to both Scan and Remediate tasks
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan_or_remediate"
+      append_value: "True"
+
   # `ContentFromTemplate` generates bigfix content from a mustache template file
   #   The file is filled out with variables from the Template Dictionary
   #   If variables are missing from the Template Dictionary, then that area will be blank
@@ -34,7 +42,7 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%NAME%-Universal-JRE-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - Official.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`
@@ -58,15 +66,18 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       # template_file_path: "%template_file_path%"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - Remediate.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - Remediate - Official.bes"
 
   - Processor: com.github.jgstew.SharedProcessors/BESImport
 
-
-  # Build "Undo-Remediation" version of fixlet by removing the 'remediate' key and adding 'undo-remediate' key
+  # Build "Undo-Remediation" version of fixlet by removing the common "scan_or_remediate" key and the 'remediate' key and adding 'undo-remediate' key
   # - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryRemove
   #   Arguments:
   #     remove_key: "remediate"
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan_or_remediate"
+      append_value: ""
 
   - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
     Arguments:
@@ -78,7 +89,85 @@ Process:
       append_key: "undo-remediate"
       append_value: "undo-remediate"
   
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - UNDO Remediation - Official.bes"
+  
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
 
+# Remove the "undo-remediate" key to start fresh band build Community versions of each
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "undo-remediate"
+      append_value: ""
+
+
+  # Build "community" versions of each, without the Community Test descriptions
+  #####
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "communityversion"
+      append_value: "true"
+
+  # "scan_or_remediate" key is common to both Scan and Remediate tasks
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan_or_remediate"
+      append_value: "True"
+
+  # `ContentFromTemplate` generates bigfix content from a mustache template file
+  #   The file is filled out with variables from the Template Dictionary
+  #   If variables are missing from the Template Dictionary, then that area will be blank
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan"
+      append_value: "scan"
+
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      template_file_path: "./%VendorFolder%/%NAME%-Universal-JRE-run.bes.mustache"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE.bes"
+
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
+
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan"
+      append_value: ""
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: "--force-fix"
+
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - Remediate.bes"
+
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
+
+  # Build "Undo-Remediation" version of fixlet by removing the common "scan_or_remediate" key and the 'remediate' key and adding 'undo-remediate' key
+  # - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryRemove
+  #   Arguments:
+  #     remove_key: "remediate"
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan_or_remediate"
+      append_value: ""
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: ""
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "undo-remediate"
+      append_value: "undo-remediate"
+  
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       # template_file_path: "%template_file_path%"

--- a/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
@@ -26,6 +26,11 @@ Process:
   # `ContentFromTemplate` generates bigfix content from a mustache template file
   #   The file is filled out with variables from the Template Dictionary
   #   If variables are missing from the Template Dictionary, then that area will be blank
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan"
+      append_value: "scan"
+
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%NAME%-Universal-JRE-run.bes.mustache"
@@ -36,6 +41,15 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/BESImport
   
   # Build "Remediation" version of fixlet
+  # Build "Remediation" version of fixlet by removing the 'scan' key and adding 'remediate' key
+  # - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryRemove
+  #   Arguments:
+  #     remove_key: "scan"
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan"
+      append_value: ""
+
   - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
     Arguments:
       append_key: "remediate"
@@ -45,5 +59,29 @@ Process:
     Arguments:
       # template_file_path: "%template_file_path%"
       content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - Remediate.bes"
+
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
+
+
+  # Build "Undo-Remediation" version of fixlet by removing the 'remediate' key and adding 'undo-remediate' key
+  # - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryRemove
+  #   Arguments:
+  #     remove_key: "remediate"
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: ""
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "undo-remediate"
+      append_value: "undo-remediate"
+  
+
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - UNDO Remediation.bes"
   
   - Processor: com.github.jgstew.SharedProcessors/BESImport

--- a/Logpresso/log4j2-scan-Universal-JRE.download.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal-JRE.download.recipe.yaml
@@ -6,7 +6,7 @@ Input:
   # TYPE must be `zip` or `7z` or `tar.gz`
   TYPE: jar
   OS: ""
-  version: "2.6.1"
+  version: "2.7.1"
 MinimumVersion: "2.3"
 ParentRecipe: com.github.jgstew.download.log4j2-scan-Win64
 Process:

--- a/Logpresso/log4j2-scan-Universal-run.bes.mustache
+++ b/Logpresso/log4j2-scan-Universal-run.bes.mustache
@@ -1,20 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BES xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BES.xsd">
 	<{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
-		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - System JRE{{#remediate}} - WITH REMEDIATION{{/remediate}}</Title>
+		<Title>Run: {{DisplayName}} v{{version}} - Universal JAR - System JRE{{#scan}} - SCAN only{{/scan}}{{#remediate}} - WITH REMEDIATION{{/remediate}}{{#undo-remediate}} - UNDO REMEDIATION{{/undo-remediate}}{{#communityversion}} - Community Version{{/communityversion}}</Title>
 		<Description><![CDATA[
+		{{#communityversion}}
 		{{>Description-CommunityTestStatement}}
 		</P>
 		{{>Log4J2Scan-Description-Links}}
 		</P>
-		{{>Log4J2Scan-Description}}
+		{{/communityversion}}
+	    {{^communityversion}}
+	    {{>Log4j2Scan-Description-OfficialVersion}}
+    	{{/communityversion}}
+		{{#scan_or_remediate}}
+		{{>Log4J2Scan-Description-ExclusionTable}}
+		{{/scan_or_remediate}}
 		</P>
 		{{#remediate}}{{>Log4JScan-Description-Remediation}}{{/remediate}}
-
+        {{#undo-remediate}}{{>Log4JScan-Description-Undo-Remediation}}{{/undo-remediate}}
 		<P><H3>NOTE:</H3> This version of the scan fixlet downloads the JAR version of {{DisplayName}}.  The system-default Java Runtime will be used.&nbsp; This requires the Java command to be present in the default system PATH variable.</P>
 		]]>		</Description>
 		<Relevance>if exists property "in proxy agent context" then not in proxy agent context else true</Relevance>
 		<Relevance>exists files whose(name of it as lowercase = "java" OR name of it as lowercase = "java.exe") of ( ( (folders it) of unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it; (if (windows of operating system) then (x64 variables "PATH" of it) else NOTHINGS) ) of environments ) ; ( (folders "bin" of folders of folders of (folders "\Program Files"; folder "\Program Files (x86)")) ) )</Relevance>
+		{{#undo-remediate}}<Relevance><![CDATA[exists find files "log4j2_scan_backup_*.zip" of folders "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"]]></Relevance> {{/undo-remediate}}
 		<Category></Category>
 		<DownloadSize>{{DownloadSize}}{{^DownloadSize}}0{{/DownloadSize}}</DownloadSize>
 		<Source>{{DisplayName}}</Source>
@@ -36,7 +44,7 @@
 			<Value>01:00:00</Value>
 		</MIMEField>
 		<Domain>BESC</Domain>
-		<DefaultAction ID="Action1">
+		<{{#scan}}DefaultAction{{/scan}}{{^scan}}Action{{/scan}} ID="Action1">
 			<Description>
 				<PreLink>Click </PreLink>
 				<Link>here</Link>
@@ -54,63 +62,83 @@ utility __Download/logpresso-log4j2-scan.jar
 
 folder create {pathname of parent folder of parent folder of client folder of site "actionsite"}/BPS-Scans
 parameter "BPSFolder"="{pathname of folder "BPS-Scans" of parent folder of parent folder of client folder of site "actionsite"}{if windows of operating system then "\" else "/"}"
+{{#scan_or_remediate}}
 parameter "ListFile"="{parameter "BPSFolder"}results-log4j2-scan.txt"
 parameter "ExclusionFile"="{parameter "BPSFolder"}log4j2-path-exclusions.txt"
+parameter "ReportJSONFile"="{parameter "BPSFolder"}log4j2-report.json"
+{{/scan_or_remediate}}
+{{#undo-remediate}}
+parameter "RestoreListFile"="{parameter "BPSFolder"}restore-log4j2-scan.txt"
+{{/undo-remediate}}
+
 
 // Setup logpresso-log4j2-scan.jar
-if { exists file "logpresso-log4j2-scan.jar" of folder (parameter "BPSFolder")}
+if { exists files "logpresso-log4j2-scan.jar" of folders (parameter "BPSFolder")}
   delete "{pathname of file "logpresso-log4j2-scan.jar" of folder (parameter "BPSFolder")}"
 endif
 
 // Copy the scanner JAR file to client folder
 copy __Download/logpresso-log4j2-scan.jar "{parameter "BPSFolder"}/logpresso-log4j2-scan.jar"
 
-// Delete previous items
-delete "{parameter "ListFile"}"
-delete __appendfile
-delete "{parameter "ExclusionFile"}"
-
-//build exclusions list
-appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of (unique values of (it as trimmed string) whose(it != "") of substrings separated by "%0a" of (parameter "exclusionlist" | ""))}
-
-appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of ("/mnt";"/dev";"/cdrom")}
-
-if {exists properties "type" of types "filesystem"}
- appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of mount points of filesystems whose (type of it != "DRIVE_FIXED" ) }
-endif
-
-//mac-specific
-if {exists properties "type" of types "volume"}
- appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of (it as string) of volumes whose (type of it != "DRIVE_FIXED" ) }
-endif
-
-if {exists properties "filesystem type" of types "filesystem"}
- appendfile {concatenation (if windows of operating system then "%0d%0a" else "%0a") of mount points of filesystems whose (filesystem type of it is contained by set of ("cgroup";"cifs";"nfs";"nfs3";"nfs4";"cgroup2";"sysfs";"proc";"cpuset") ) }
-endif
-
-copy __appendfile "{parameter "ExclusionFile"}"
+{{#scan_or_remediate}}{{>Log4J2Scan-Action-ExcludeList}}{{/scan_or_remediate}}
 
 
 if {windows of operating system}
-  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & java -jar .\logpresso-log4j2-scan.jar --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config "{parameter "ExclusionFile"}" {{remediate}} > "{parameter "ListFile"}""
+  {{#scan_or_remediate}}
+  delete "{parameter "ReportJSONFile"}"
+  runhidden cmd.exe /c "cd "{parameter "BPSFolder"}" & java -jar .\logpresso-log4j2-scan.jar --silent --all-drives --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config "{parameter "ExclusionFile"}" --report-json --report-path "{parameter "ReportJSONFile"}" {{remediate}} > "{parameter "ListFile"}""
+  {{/scan_or_remediate}}
+  {{#undo-remediate}}
+  delete __appendfile
+  appendfile cd "{parameter "BPSFolder"}"
+  appendfile del /q "{parameter "RestoreListFile"}"
+  appendfile {concatenation "%0d%0a" of ("java -jar %22" & parameter "BPSFolder" & "logpresso-log4j2-scan.jar%22  --restore %22" & it & "%22 >> %22" & parameter "RestoreListFile" & "%22 2>&1"; "echo move /Y %22" & it & "%22 %22" & it & ".restored%22") of pathnames of find files "log4j2_scan_backup_*.zip" of folders (parameter "BPSFolder")}
+   
+  delete log4j-restore.cmd
+  move __appendfile log4j-restore.cmd
+  waithidden cmd.exe /c log4j-restore.cmd
+
+  {{/undo-remediate}}  
 else // non-Windows operating system:
   // Get shell binary, should return /bin/sh in most cases:
   parameter "shell_bin" = "{  tuple string items 0 of concatenations ", " of ( pathnames of files "/bin/sh"; pathnames of files whose(name of it as lowercase = "sh" OR name of it as lowercase = "sh.exe") of (folders it) of unique values of (it as trimmed string) of substrings separated by (";";":") of values of (variables "PATH" of it ) of environments) }"
 
-  // Run log4j2-scan:
+  {{#scan_or_remediate}}
+  // Run log4j2-scan scan or remediation:
   // WARNING: this attempts to exclude network shares, but might not be perfect.
-  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' && java -jar ./logpresso-log4j2-scan.jar --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660 --exclude-config '{parameter "ExclusionFile"}'  {{remediate}} / > '{parameter "ListFile"}'"
+  delete "{parameter "ReportJSONFile"}"
+  run {parameter "shell_bin"} -c "cd '{parameter "BPSFolder"}' ; java -jar ./logpresso-log4j2-scan.jar --silent --scan-log4j1 --no-symlink --no-empty-report --exclude-fs nfs,nfs3,nfs4,cifs,tmpfs,devtmpfs,iso9660,autofs,afs --exclude-config '{parameter "ExclusionFile"}'  --report-json --report-path '{parameter "ReportJSONFile"}' {{remediate}} / > '{parameter "ListFile"}'"
+  {{/scan_or_remediate}}
+  {{#undo-remediate}}
+  delete __appendfile
+  appendfile #!/bin/sh
+  appendfile cd '{parameter "BPSFolder"}' 
+  appendfile rm -f "{parameter "RestoreListFile"}"
+  appendfile {concatenation "%0a" of ("%22" & parameter "Java_bin" & "%22 -jar %22" & parameter "BPSFolder" & "logpresso-log4j2-scan.jar%22  --restore %22" & it & "%22 >> %22" & parameter "RestoreListFile" & "%22 2>&1 "; "echo mv -f %22" & it & "%22 %22" & it & ".restored%22") of pathnames of find files "log4j2_scan_backup_*.zip" of folders (parameter "BPSFolder")}
+  appendfile rm -rf '{parameter "JREFolder"}'
+  delete log4j-restore.sh
+  move __appendfile log4j-restore.sh
+  wait chmod +x log4j-restore.sh
+  wait {parameter "shell_bin"} ./log4j-restore.sh
+  {{/undo-remediate}}
 endif
 
-// Give 30 seconds for startup before checking
+
+{{#scan_or_remediate}}
+// Wait up to 30 seconds for the logfile to be created to check successful startup
 parameter "StartTime"="{now}"
 pause while {not exists file (parameter "ListFile") and now - (parameter "StartTime" as time) < 30 * second }
 // Check that an output log file has been created as an indicator that the scan has launched successfully
 continue if {exists file (parameter "ListFile") whose (modification time of it >= active start time of action)}
-
-{{#remediate}}action requires restart{{/remediate}}
-
+{{#remediate}}
+action requires restart
+{{/remediate}}
+{{/scan_or_remediate}}
+{{#undo-remediate}}
+continue if {exists file (parameter "RestoreListFile") whose (modification time of it >= active start time of action)}
+action requires restart
+{{/undo-remediate}}
 // End]]></ActionScript>
-		</DefaultAction>
+		</{{#scan}}DefaultAction{{/scan}}{{^scan}}Action{{/scan}}>
 	</{{TypeTaskOrFixlet}}{{^TypeTaskOrFixlet}}Task{{/TypeTaskOrFixlet}}>
 </BES>

--- a/Logpresso/log4j2-scan-Universal.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal.bigfix.recipe.yaml
@@ -23,17 +23,44 @@ Process:
 
   - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppendInput
 
+  # Build "community" versions of each, without the Community Test descriptions
+  #####
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "communityversion"
+      append_value: "true"
+
+  # "scan_or_remediate" key is common to both Scan and Remediate tasks
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan_or_remediate"
+      append_value: "True"
+
+  # `ContentFromTemplate` generates bigfix content from a mustache template file
+  #   The file is filled out with variables from the Template Dictionary
+  #   If variables are missing from the Template Dictionary, then that area will be blank
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan"
+      append_value: "scan"
+  
   # `ContentFromTemplate` generates bigfix content from a mustache template file
   #   The file is filled out with variables from the Template Dictionary
   #   If variables are missing from the Template Dictionary, then that area will be blank
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%NAME%-Universal-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - Universal.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`
   - Processor: com.github.jgstew.SharedProcessors/BESImport
+
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan"
+      append_value: ""
 
   - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
     Arguments:
@@ -43,8 +70,33 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       # template_file_path: "%template_file_path%"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso log4j2-scan - Universal - Remediate.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - Remediate.bes"
   
   - Processor: com.github.jgstew.SharedProcessors/BESImport
 
+  # Build "Undo-Remediation" version of fixlet by removing the common "scan_or_remediate" key and the 'remediate' key and adding 'undo-remediate' key
+  # - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryRemove
+  #   Arguments:
+  #     remove_key: "remediate"
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "scan_or_remediate"
+      append_value: ""
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "remediate"
+      append_value: ""
+
+  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
+    Arguments:
+      append_key: "undo-remediate"
+      append_value: "undo-remediate"
+  
+  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
+    Arguments:
+      # template_file_path: "%template_file_path%"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - UNDO Remediation.bes"
+  
+  - Processor: com.github.jgstew.SharedProcessors/BESImport
 

--- a/SharedProcessors/TemplateDictionaryRemove.py
+++ b/SharedProcessors/TemplateDictionaryRemove.py
@@ -1,0 +1,63 @@
+#!/usr/local/autopkg/python
+#
+# James Stewart @JGStew - 2021
+#
+# Related:
+# - https://github.com/jgstew/bigfix_prefetch/blob/master/prefetch_from_dictionary.py
+#
+"""See docstring for TemplateDictionaryRemove class"""
+
+
+from autopkglib import (  # pylint: disable=import-error,wrong-import-position,unused-import
+    Processor,
+    ProcessorError,
+)
+
+__all__ = ["TemplateDictionaryRemove"]
+
+
+class TemplateDictionaryRemove(Processor):  # pylint: disable=invalid-name
+    """Removes a key from the input dictionary"""
+
+    description = __doc__
+    input_variables = {
+        "dictionary_name": {
+            "required": False,
+            "default": "template_dictionary",
+            "description": "python dictionary from which to remove key",
+        },
+        "remove_key": {
+            "required": True,
+            "description": "the key to remove from the python dictionary",
+        },
+    }
+    output_variables = {
+        "dictionary_name": {"description": ("The reduced dictionary name")},
+        "dictionary_reduced": {"description": ("The reduced dictionary")},
+    }
+    __doc__ = description
+
+    def main(self):
+        """Execution starts here"""
+
+        # get the current dictionary
+        dictionary_name = self.env.get("dictionary_name", "template_dictionary")
+        dictionary_to_reduce = self.env.get(dictionary_name, {})
+
+        self.output(f"dictionary_to_reduce: {dictionary_to_reduce}", 2)
+
+        remove_key = self.env.get("remove_key")
+
+        # ensure it is a dict
+        dictionary_to_reduce = dict(dictionary_to_reduce)
+
+        dictionary_to_reduce.pop(remove_key, None)
+
+        # write back the dict to itself
+        self.env[dictionary_name] = dictionary_to_reduce
+        self.env["dictionary_reduced"] = dictionary_to_reduce
+
+
+if __name__ == "__main__":
+    PROCESSOR = TemplateDictionaryRemove()
+    PROCESSOR.execute_shell()


### PR DESCRIPTION
A lot.
- Shared Processor to remove dictionary key.  Later OBE, I get the same effect in Recipe by setting the key to empty string instead anyway.  Keeping it as it may still be useful.  Examples (commented) in the Recipe.
- Add Recipe key to undo-remediate, and update the mustache to add undo-remediation option.
- Add a dictionary key for "scan" explicitly
- Remove DefaultAction for "remediate" and "undo-remediate"
- Generate JSON report on "scan" and "remediate"
- Explicitly cleanup files from __Download folder
- Update the "unzip.exe" command line to overwrite any existing JRE folder