### PR TITLE
Stop building separate Community versions

### DIFF
--- a/.templates/.partials/Log4JScan-Description-Remediation.mustache
+++ b/.templates/.partials/Log4JScan-Description-Remediation.mustache
@@ -1,1 +1,5 @@
-<P><H3>This Action will attempt to remediate the vulnerability by using Log4j-Scan to modify the affected JAR files and remove the JndiLookup.class entry.</H3></P>
+<P><H3>This Action will attempt to remediate the vulnerability by using Log4j-Scan to modify the affected JAR files and remove the JndiLookup.class entry.</P>
+HCL BigFix cannot determine whether remediating vulnerable Log4j-core-2.x.jar files will have a negative impact on any applications.<br>
+Use this task to perform Remediation with care and test thoroughly in your environment.<H3><br>
+
+

--- a/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
+++ b/Logpresso/log4j2-scan-Universal-JRE.bigfix.recipe.yaml
@@ -42,7 +42,7 @@ Process:
   - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
     Arguments:
       template_file_path: "./%VendorFolder%/%NAME%-Universal-JRE-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - Official.bes"
+      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE.bes"
 
   # `BESImport` imports the generated BES content into a BigFix Server
   #   Which server and credentials are used is dictated by `~/.besapi.conf`
@@ -53,85 +53,6 @@ Process:
   # - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryRemove
   #   Arguments:
   #     remove_key: "scan"
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "scan"
-      append_value: ""
-
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "remediate"
-      append_value: "--force-fix"
-
-  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
-    Arguments:
-      # template_file_path: "%template_file_path%"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - Remediate - Official.bes"
-
-  - Processor: com.github.jgstew.SharedProcessors/BESImport
-
-  # Build "Undo-Remediation" version of fixlet by removing the common "scan_or_remediate" key and the 'remediate' key and adding 'undo-remediate' key
-  # - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryRemove
-  #   Arguments:
-  #     remove_key: "remediate"
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "scan_or_remediate"
-      append_value: ""
-
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "remediate"
-      append_value: ""
-
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "undo-remediate"
-      append_value: "undo-remediate"
-
-  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
-    Arguments:
-      # template_file_path: "%template_file_path%"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE - UNDO Remediation - Official.bes"
-
-  - Processor: com.github.jgstew.SharedProcessors/BESImport
-
-# Remove the "undo-remediate" key to start fresh band build Community versions of each
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "undo-remediate"
-      append_value: ""
-
-
-  # Build "community" versions of each, without the Community Test descriptions
-  #####
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "communityversion"
-      append_value: "true"
-
-  # "scan_or_remediate" key is common to both Scan and Remediate tasks
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "scan_or_remediate"
-      append_value: "True"
-
-  # `ContentFromTemplate` generates bigfix content from a mustache template file
-  #   The file is filled out with variables from the Template Dictionary
-  #   If variables are missing from the Template Dictionary, then that area will be blank
-  - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
-    Arguments:
-      append_key: "scan"
-      append_value: "scan"
-
-  - Processor: com.github.jgstew.SharedProcessors/ContentFromTemplate
-    Arguments:
-      template_file_path: "./%VendorFolder%/%NAME%-Universal-JRE-run.bes.mustache"
-      content_file_pathname: "%RECIPE_CACHE_DIR%/Logpresso Log4j2-scan - Universal - JRE.bes"
-
-  - Processor: com.github.jgstew.SharedProcessors/BESImport
-
-
   - Processor: com.github.jgstew.SharedProcessors/TemplateDictionaryAppend
     Arguments:
       append_key: "scan"


### PR DESCRIPTION
Change the descriptions to use "Official Version" descriptions, and stop building separate "Community Version" of the fixlets.